### PR TITLE
Extra period validations

### DIFF
--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -12,6 +12,6 @@ module Interval
   def period_dates_validation
     return if [started_on, finished_on].any?(&:blank?)
 
-    errors.add(:finished_on, "Must be later than :started_on") if finished_on <= started_on
+    errors.add(:finished_on, "The finish date must be later than the start date") if finished_on <= started_on
   end
 end

--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -6,8 +6,6 @@ module Interval
     validate :period_dates_validation
 
     # Scopes
-    scope :extending_later_than, ->(date) { where("finished_on IS NULL OR finished_on > ?", date) }
-    scope :starting_earlier_than, ->(date) { where("started_on < ?", date) }
     scope :overlapping_with, ->(period) { where("range && daterange(?, ?)", period.started_on, period.finished_on) }
   end
 

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -9,13 +9,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_many :training_periods, inverse_of: :ect_at_school_period
 
   # Validations
-  validates :finished_on,
-            uniqueness: { scope: :teacher_id,
-                          allow_nil: true }
-
   validates :started_on,
-            presence: true,
-            uniqueness: { scope: :teacher_id }
+            presence: true
 
   validates :school_id,
             presence: true

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -24,6 +24,8 @@ class InductionPeriod < ApplicationRecord
                          message: "Choose an induction programme" }
 
   validate :teacher_distinct_period
+  validate :enveloped_by_ect_at_school_period,
+           if: -> { ect_at_school_period.present? && started_on.present? }
 
   # Scopes
   scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
@@ -35,5 +37,11 @@ private
   def teacher_distinct_period
     overlapping_siblings = InductionPeriod.siblings_of(self).overlapping_with(self).exists?
     errors.add(:base, "Teacher induction periods cannot overlap") if overlapping_siblings
+  end
+
+  def enveloped_by_ect_at_school_period
+    return if (ect_at_school_period.started_on..ect_at_school_period.finished_on).cover?(started_on..finished_on)
+
+    errors.add(:base, "Date range is not contained by the ECT at school period")
   end
 end

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -6,15 +6,8 @@ class InductionPeriod < ApplicationRecord
   belongs_to :ect_at_school_period, class_name: "ECTAtSchoolPeriod", inverse_of: :induction_periods
 
   # Validations
-  validates :finished_on,
-            uniqueness: { scope: :ect_at_school_period_id,
-                          message: "matches the end date of an existing period for ECT",
-                          allow_nil: true }
-
   validates :started_on,
-            presence: true,
-            uniqueness: { scope: :ect_at_school_period_id,
-                          message: "matches the start date of an existing period for ECT" }
+            presence: true
 
   validates :appropriate_body_id,
             presence: true

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -8,15 +8,8 @@ class MentorAtSchoolPeriod < ApplicationRecord
   has_many :training_periods, inverse_of: :mentor_at_school_period
 
   # Validations
-  validates :finished_on,
-            uniqueness: { scope: %i[teacher_id school_id],
-                          message: "matches the end date of an existing period",
-                          allow_nil: true }
-
   validates :started_on,
-            presence: true,
-            uniqueness: { scope: %i[teacher_id school_id],
-                          message: "matches the start date of an existing period" }
+            presence: true
 
   validates :school_id,
             presence: true

--- a/app/models/mentorship_period.rb
+++ b/app/models/mentorship_period.rb
@@ -13,15 +13,8 @@ class MentorshipPeriod < ApplicationRecord
              inverse_of: :mentorship_periods
 
   # Validations
-  validates :finished_on,
-            uniqueness: { scope: :ect_at_school_period_id,
-                          message: "matches the end date of an existing period for mentee",
-                          allow_nil: true }
-
   validates :started_on,
-            presence: true,
-            uniqueness: { scope: :ect_at_school_period_id,
-                          message: "matches the start date of an existing period for mentee" }
+            presence: true
 
   validates :ect_at_school_period_id,
             presence: true

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -8,15 +8,8 @@ class TrainingPeriod < ApplicationRecord
   has_many :declarations, inverse_of: :training_period
 
   # Validations
-  validates :finished_on,
-            uniqueness: { scope: %i[ect_at_school_period_id mentor_at_school_period_id],
-                          message: "matches the end date of an existing period for trainee",
-                          allow_nil: true }
-
   validates :started_on,
-            presence: true,
-            uniqueness: { scope: %i[ect_at_school_period_id mentor_at_school_period_id],
-                          message: "matches the start date of an existing period for trainee" }
+            presence: true
 
   validates :provider_partnership_id,
             presence: true

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -15,7 +15,8 @@ class TrainingPeriod < ApplicationRecord
             presence: true
 
   validate :one_id_of_trainee_present
-  validate :trainee_distinct_period
+  validate :trainee_distinct_period, if: -> { ect_at_school_period.present? }
+  validate :mentor_distinct_period, if: -> { mentor_at_school_period.present? }
 
   validate :enveloped_by_ect_at_school_period,
            if: -> { ect_at_school_period.present? && started_on.present? }
@@ -54,6 +55,11 @@ private
   def trainee_distinct_period
     overlapping_siblings = TrainingPeriod.trainee_siblings_of(self).overlapping_with(self).exists?
     errors.add(:base, "Trainee periods cannot overlap") if overlapping_siblings
+  end
+
+  def mentor_distinct_period
+    overlapping_siblings = TrainingPeriod.mentor_siblings_of(self).overlapping_with(self).exists?
+    errors.add(:base, "Mentor periods cannot overlap") if overlapping_siblings
   end
 
   def enveloped_by_ect_at_school_period

--- a/spec/factories/mentorship_period_factory.rb
+++ b/spec/factories/mentorship_period_factory.rb
@@ -2,9 +2,6 @@ FactoryBot.define do
   sequence(:base_mentorship_date) { |n| 2.years.ago.to_date + (3 * n).months }
 
   factory(:mentorship_period) do
-    association :mentee, factory: :ect_at_school_period
-    association :mentor, factory: :mentor_at_school_period
-
     started_on { generate(:base_mentorship_date) }
     finished_on { started_on + 3.months }
 

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -11,7 +11,7 @@ describe Interval do
         end
 
         it "add an error" do
-          expect(subject.errors.messages).to include(finished_on: ["Must be later than :started_on"])
+          expect(subject.errors.messages).to include(finished_on: ["The finish date must be later than the start date"])
         end
       end
 
@@ -23,7 +23,7 @@ describe Interval do
         end
 
         it "add an error" do
-          expect(subject.errors.messages).to include(finished_on: ["Must be later than :started_on"])
+          expect(subject.errors.messages).to include(finished_on: ["The finish date must be later than the start date"])
         end
       end
     end

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -40,26 +40,6 @@ describe Interval do
       DummyMentor.create(teacher_id: teacher_2_id, school_id:, started_on: '2023-02-01', finished_on: '2023-07-01')
     end
 
-    describe ".extending_later_than" do
-      it "returns periods with finished_on later than the specified date or not finished" do
-        expect(DummyMentor.extending_later_than('2023-05-01')).to match_array([period_1, period_2, period_3, teacher_2_period])
-      end
-
-      it "does not return periods finished before the specified date" do
-        expect(DummyMentor.extending_later_than('2023-07-02')).to match_array([period_2, period_3])
-      end
-    end
-
-    describe ".starting_earlier_than" do
-      it "returns periods with started_on earlier than the specified date" do
-        expect(DummyMentor.starting_earlier_than('2023-08-01')).to match_array([period_1, period_2, teacher_2_period])
-      end
-
-      it "does not return periods with started_on on or after the specified date" do
-        expect(DummyMentor.starting_earlier_than('2023-01-01')).to be_empty
-      end
-    end
-
     describe ".overlapping_with" do
       it "returns periods overlapping with the specified date range" do
         expect(DummyMentor.overlapping_with(FakePeriod.new('2023-02-01', '2023-10-01'))).to match_array([period_1, period_2, teacher_2_period])

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -10,9 +10,7 @@ describe ECTAtSchoolPeriod do
   describe "validations" do
     subject { FactoryBot.create(:ect_at_school_period) }
 
-    it { is_expected.to validate_uniqueness_of(:finished_on).scoped_to(:teacher_id).allow_nil }
     it { is_expected.to validate_presence_of(:started_on) }
-    it { is_expected.to validate_uniqueness_of(:started_on).scoped_to(:teacher_id) }
     it { is_expected.to validate_presence_of(:school_id) }
     it { is_expected.to validate_presence_of(:teacher_id) }
 

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -7,18 +7,6 @@ describe InductionPeriod do
   describe "validations" do
     subject { FactoryBot.create(:induction_period) }
 
-    it {
-      is_expected.to validate_uniqueness_of(:finished_on)
-                          .scoped_to(:ect_at_school_period_id)
-                          .allow_nil
-                          .with_message("matches the end date of an existing period for ECT")
-    }
-
-    it {
-      is_expected.to validate_uniqueness_of(:started_on)
-                          .scoped_to(:ect_at_school_period_id)
-                          .with_message("matches the start date of an existing period for ECT")
-    }
     it { is_expected.to validate_presence_of(:appropriate_body_id) }
     it { is_expected.to validate_presence_of(:ect_at_school_period_id) }
 

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -5,7 +5,8 @@ describe InductionPeriod do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:induction_period) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 2.years.ago, finished_on: nil) }
+    subject { FactoryBot.build(:induction_period, ect_at_school_period:) }
 
     it { is_expected.to validate_presence_of(:appropriate_body_id) }
     it { is_expected.to validate_presence_of(:ect_at_school_period_id) }
@@ -13,38 +14,55 @@ describe InductionPeriod do
     describe "teacher distinct period" do
       context "when the period has not finished yet" do
         context "when the ect has a sibling induction period starting later" do
-          let!(:existing_period) { FactoryBot.create(:induction_period) }
-          let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
-          let(:started_on) { existing_period.started_on - 1.year }
-
-          subject { FactoryBot.build(:induction_period, ect_at_school_period_id:, started_on:, finished_on: nil) }
+          let!(:existing_period) { FactoryBot.create(:induction_period, ect_at_school_period:, started_on: 1.year.ago) }
+          subject { FactoryBot.build(:induction_period, ect_at_school_period:, started_on: existing_period.started_on, finished_on: nil) }
 
           before do
             subject.valid?
           end
 
           it "add an error" do
-            expect(subject.errors.messages).to include(base: ["Teacher induction periods cannot overlap"])
+            expect(subject.errors.messages[:base]).to include("Teacher induction periods cannot overlap")
           end
         end
       end
 
       context "when the period has end date" do
         context "when the ECT has a sibling induction period overlapping" do
-          let!(:existing_period) { FactoryBot.create(:induction_period) }
-          let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
-          let(:started_on) { existing_period.finished_on - 1.day }
-          let(:finished_on) { started_on + 1.day }
-
-          subject { FactoryBot.build(:induction_period, ect_at_school_period_id:, started_on:, finished_on:) }
+          let!(:existing_period) { FactoryBot.create(:induction_period, ect_at_school_period:, started_on: 1.year.ago) }
+          subject { FactoryBot.build(:induction_period, ect_at_school_period:, started_on: existing_period.started_on, finished_on: existing_period.started_on + 1.day) }
 
           before do
             subject.valid?
           end
 
           it "add an error" do
-            expect(subject.errors.messages).to include(base: ["Teacher induction periods cannot overlap"])
+            expect(subject.errors.messages[:base]).to include("Teacher induction periods cannot overlap")
           end
+        end
+      end
+    end
+
+    describe '#enveloped_by_ect_at_school_period' do
+      context 'when the ECT at school period contains the induction period' do
+        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
+
+        subject! { FactoryBot.create(:induction_period, started_on: 3.months.ago, finished_on: 2.months.ago, ect_at_school_period:) }
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context 'when the induction period extends beyond the teacher at school period' do
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
+
+        subject { FactoryBot.build(:induction_period, started_on: 5.months.ago, finished_on: 1.month.ago, ect_at_school_period:) }
+
+        it 'has an appropriate error message about the ECT at school period' do
+          subject.valid?
+
+          expect(subject.errors.messages[:base]).to include("Date range is not contained by the ECT at school period")
         end
       end
     end
@@ -65,30 +83,43 @@ describe InductionPeriod do
   end
 
   describe "scopes" do
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period) }
-    let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-    let!(:period_1) { FactoryBot.create(:induction_period, ect_at_school_period:, appropriate_body:, started_on: '2023-01-01', finished_on: '2023-06-01') }
-    let!(:period_2) { FactoryBot.create(:induction_period, ect_at_school_period:, started_on: "2023-06-01", finished_on: "2024-01-01") }
-    let!(:period_3) { FactoryBot.create(:induction_period, ect_at_school_period:, appropriate_body:, started_on: '2024-01-01', finished_on: nil) }
-    let!(:ect_2_period) { FactoryBot.create(:induction_period, appropriate_body:, started_on: '2023-02-01', finished_on: '2023-07-01') }
-
     describe ".for_ect" do
       it "returns induction periods only for the specified ect at school period" do
-        expect(described_class.for_ect(ect_at_school_period.id)).to match_array([period_1, period_2, period_3])
+        expect(InductionPeriod.for_ect(123).to_sql).to end_with(%(WHERE "induction_periods"."ect_at_school_period_id" = 123))
       end
     end
 
     describe ".for_appropriate_body" do
       it "returns induction periods only for the specified appropriate_body" do
-        expect(described_class.for_appropriate_body(appropriate_body.id)).to match_array([period_1, period_3, ect_2_period])
+        expect(InductionPeriod.for_appropriate_body(456).to_sql).to end_with(%( WHERE "induction_periods"."appropriate_body_id" = 456))
       end
     end
 
     describe ".siblings_of" do
-      let(:induction_period) { FactoryBot.build(:induction_period, ect_at_school_period:, appropriate_body:, started_on: "2022-01-01", finished_on: "2023-01-01") }
+      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+      let!(:induction_period_1) { FactoryBot.create(:induction_period, ect_at_school_period:, started_on: '2022-01-01', finished_on: '2022-06-01') }
+      let!(:induction_period_2) { FactoryBot.create(:induction_period, ect_at_school_period:, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
-      it "returns induction periods only for the specified instance's ect excluding the instance" do
-        expect(described_class.siblings_of(induction_period)).to match_array([period_1, period_2, period_3])
+      let!(:unrelated_ect_at_school_period) do
+        FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01')
+      end
+
+      let!(:unrelated_induction_period) do
+        FactoryBot.create(:induction_period, ect_at_school_period: unrelated_ect_at_school_period, started_on: '2022-06-01', finished_on: '2023-01-01')
+      end
+
+      subject { InductionPeriod.siblings_of(induction_period_1) }
+
+      it "only returns records that belong to the same mentee" do
+        expect(subject).to include(induction_period_2)
+      end
+
+      it "doesn't include itself" do
+        expect(subject).not_to include(induction_period_1)
+      end
+
+      it "doesn't include periods that belong to other mentees" do
+        expect(subject).not_to include(unrelated_induction_period)
       end
     end
   end

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -13,45 +13,6 @@ describe MentorAtSchoolPeriod do
     it { is_expected.to validate_presence_of(:school_id) }
     it { is_expected.to validate_presence_of(:teacher_id) }
 
-    context "uniqueness of finished_on scoped to teacher_id and school_id" do
-      context "when the period matches the teacher_id, school_id and finished_on values of an existing mentor period" do
-        let!(:existing_period) { FactoryBot.create(:mentor_at_school_period) }
-        let(:finished_on) { existing_period.finished_on }
-        let(:started_on) { existing_period.finished_on - 1.day }
-        let(:school_id) { existing_period.school_id }
-        let(:teacher_id) { existing_period.teacher_id }
-
-        subject { FactoryBot.build(:mentor_at_school_period, teacher_id:, school_id:, started_on:, finished_on:) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(finished_on: ["matches the end date of an existing period"])
-        end
-      end
-    end
-
-    context "uniqueness of started_on scoped to teacher_id and school_id" do
-      context "when the period matches the teacher_id, school_id and started_on values of an existing mentor period" do
-        let!(:existing_period) { FactoryBot.create(:mentor_at_school_period) }
-        let(:started_on) { existing_period.started_on }
-        let(:school_id) { existing_period.school_id }
-        let(:teacher_id) { existing_period.teacher_id }
-
-        subject { FactoryBot.build(:mentor_at_school_period, teacher_id:, school_id:, started_on:) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(started_on: ["matches the start date of an existing period"])
-        end
-      end
-    end
-
     context "teacher school distinct period" do
       context "when the period has not finished yet" do
         context "when the teacher has a school sibling mentor_at_school_period starting later" do

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -5,46 +5,117 @@ describe MentorshipPeriod do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:mentorship_period) }
+    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 2.years.ago) }
+    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 2.years.ago) }
+    let(:started_on) { 2.months.ago }
+    let(:finished_on) { nil }
+
+    subject do
+      FactoryBot.build(
+        :mentorship_period,
+        started_on:,
+        finished_on:,
+        mentee: ect_at_school_period,
+        mentor: mentor_at_school_period
+      )
+    end
 
     it { is_expected.to validate_presence_of(:started_on) }
     it { is_expected.to validate_presence_of(:ect_at_school_period_id) }
     it { is_expected.to validate_presence_of(:mentor_at_school_period_id) }
 
-    context "mentee distinct period" do
-      context "when the period has not finished yet" do
-        context "when the mentee has a sibling mentorship periods starting later" do
-          let!(:existing_period) { FactoryBot.create(:mentorship_period) }
-          let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
-          let(:started_on) { existing_period.started_on - 1.year }
-
-          subject { FactoryBot.build(:mentorship_period, ect_at_school_period_id:, started_on:, finished_on: nil) }
+    describe '#mentee_distinct_period' do
+      context 'when periods overlap' do
+        context 'when the mentee has a sibling mentorship periods that overlaps' do
+          let(:finished_on) { nil }
 
           before do
+            subject.dup.save!
             subject.valid?
           end
 
-          it "add an error" do
-            expect(subject.errors.messages).to include(base: ["Mentee periods cannot overlap"])
+          it 'adds an error' do
+            expect(subject.errors.messages[:base]).to include("Mentee periods cannot overlap")
+          end
+        end
+
+        context 'when a new mentorship period starts on the day a previous one ends' do
+          before do
+            subject.dup.tap do |old_period|
+              old_period.started_on = subject.started_on - 2.months
+              old_period.finished_on = subject.started_on
+              old_period.save!
+            end
+          end
+
+          it 'is valid' do
+            expect(subject).to be_valid
+          end
+        end
+
+        context 'when a new mentorship period starts on the day before a previous one ends' do
+          before do
+            subject.dup.tap do |old_period|
+              old_period.started_on = subject.started_on - 2.months
+              old_period.finished_on = subject.started_on + 1
+              old_period.save!
+            end
+
+            subject.valid?
+          end
+
+          it 'adds an error' do
+            expect(subject.errors.messages[:base]).to include("Mentee periods cannot overlap")
+          end
+        end
+
+        context 'when an existing mentorship period is ongoing' do
+          before do
+            subject.dup.tap do |old_period|
+              old_period.started_on = subject.started_on - 2.months
+              old_period.finished_on = nil
+              old_period.save!
+            end
+
+            subject.valid?
+          end
+
+          it 'a new period starting now results in an error' do
+            expect(subject.errors.messages[:base]).to include("Mentee periods cannot overlap")
           end
         end
       end
+    end
 
-      context "when the period has end date" do
-        context "when the mentee has a sibling mentorship_period overlapping" do
-          let!(:existing_period) { FactoryBot.create(:mentorship_period) }
-          let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
-          let(:started_on) { existing_period.finished_on - 1.day }
-          let(:finished_on) { started_on + 1.day }
+    describe 'period containment' do
+      describe '#enveloped_by_ect_at_school_period' do
+        context 'when the ECT at school period contains the mentorship period' do
+          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
+          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
 
-          subject { FactoryBot.build(:mentorship_period, ect_at_school_period_id:, started_on:, finished_on:) }
+          subject! { FactoryBot.create(:mentorship_period, started_on: 3.months.ago, finished_on: 2.months.ago, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
 
-          before do
+          it 'is valid' do
+            expect(subject).to be_valid
+          end
+        end
+
+        context 'when the mentorship period extends beyond the teacher and mentor at school periods' do
+          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
+          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
+
+          subject { FactoryBot.build(:mentorship_period, started_on: 5.months.ago, finished_on: 1.month.ago, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
+
+          it 'has an appropriate error message about the ECT at school period' do
             subject.valid?
+
+            expect(subject.errors.messages[:base]).to include("Date range is not contained by the ECT at school period")
           end
 
-          it "add an error" do
-            expect(subject.errors.messages).to include(base: ["Mentee periods cannot overlap"])
+          it 'has an appropriate error message about the mentor at school period' do
+            subject.valid?
+
+            expect(subject.errors.messages[:base]).to include("Date range is not contained by the mentor at school period")
           end
         end
       end
@@ -52,30 +123,39 @@ describe MentorshipPeriod do
   end
 
   describe "scopes" do
-    let!(:mentee) { FactoryBot.create(:ect_at_school_period) }
-    let!(:mentor) { FactoryBot.create(:mentor_at_school_period) }
-    let!(:period_1) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2023-01-01', finished_on: '2023-06-01') }
-    let!(:period_2) { FactoryBot.create(:mentorship_period, mentee:, started_on: "2023-06-01", finished_on: "2024-01-01") }
-    let!(:period_3) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2024-01-01', finished_on: nil) }
-    let!(:mentee_2_period) { FactoryBot.create(:mentorship_period, mentor:, started_on: '2023-02-01', finished_on: '2023-07-01') }
-
     describe ".for_mentee" do
-      it "returns mentorship periods only for the specified mentee" do
-        expect(described_class.for_mentee(mentee.id)).to match_array([period_1, period_2, period_3])
+      it "returns only periods for the specified mentee" do
+        expect(MentorshipPeriod.for_mentee(123).to_sql).to end_with(%(WHERE "mentorship_periods"."ect_at_school_period_id" = 123))
       end
     end
 
     describe ".for_mentor" do
-      it "returns mentorship periods only for the specified mentor" do
-        expect(described_class.for_mentor(mentor.id)).to match_array([period_1, period_3, mentee_2_period])
+      it "returns only periods for the specified mentor" do
+        expect(MentorshipPeriod.for_mentor(456).to_sql).to end_with(%(WHERE "mentorship_periods"."mentor_at_school_period_id" = 456))
       end
     end
 
     describe ".mentee_siblings_of" do
-      let(:mentorship_period) { FactoryBot.build(:mentorship_period, mentee:, mentor:, started_on: "2022-01-01", finished_on: "2023-01-01") }
+      let!(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+      let!(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: '2021-01-01') }
+      let!(:period_1) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2022-01-01', finished_on: '2022-06-01') }
+      let!(:period_2) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
-      it "returns mentorship periods only for the specified instance's mentee excluding the instance" do
-        expect(described_class.mentee_siblings_of(mentorship_period)).to match_array([period_1, period_2, period_3])
+      let!(:unrelated_mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+      let!(:unrelated_period) { FactoryBot.create(:mentorship_period, mentor:, mentee: unrelated_mentee, started_on: '2022-06-01', finished_on: '2023-01-01') }
+
+      subject { MentorshipPeriod.mentee_siblings_of(period_1) }
+
+      it "only returns records that belong to the same mentee" do
+        expect(subject).to include(period_2)
+      end
+
+      it "doesn't include itself" do
+        expect(subject).not_to include(period_1)
+      end
+
+      it "doesn't include periods that belong to other mentees" do
+        expect(subject).not_to include(unrelated_period)
       end
     end
   end

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -7,17 +7,6 @@ describe MentorshipPeriod do
   describe "validations" do
     subject { FactoryBot.create(:mentorship_period) }
 
-    it {
-      is_expected.to validate_uniqueness_of(:finished_on)
-                       .scoped_to(:ect_at_school_period_id)
-                       .allow_nil
-                       .with_message("matches the end date of an existing period for mentee")
-    }
-    it {
-      is_expected.to validate_uniqueness_of(:started_on)
-                       .scoped_to(:ect_at_school_period_id)
-                       .with_message("matches the start date of an existing period for mentee")
-    }
     it { is_expected.to validate_presence_of(:started_on) }
     it { is_expected.to validate_presence_of(:ect_at_school_period_id) }
     it { is_expected.to validate_presence_of(:mentor_at_school_period_id) }

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -7,51 +7,8 @@ describe TrainingPeriod do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:training_period) }
-
     it { is_expected.to validate_presence_of(:started_on) }
     it { is_expected.to validate_presence_of(:provider_partnership_id) }
-
-    context "uniqueness of finished_on scoped to trainee ids" do
-      context "when the period matches the ect_at_school_period_id, mentor_at_school_period_id and finished_on values
-               of an existing training period" do
-        let!(:existing_period) { FactoryBot.create(:training_period) }
-        let(:finished_on) { existing_period.finished_on }
-        let(:started_on) { existing_period.finished_on - 1.day }
-        let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
-        let(:mentor_at_school_period_id) { existing_period.mentor_at_school_period_id }
-
-        subject { FactoryBot.build(:training_period, ect_at_school_period_id:, mentor_at_school_period_id:, started_on:, finished_on:) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(finished_on: ["matches the end date of an existing period for trainee"])
-        end
-      end
-    end
-
-    context "uniqueness of started_on scoped to trainee ids" do
-      context "when the period matches the ect_at_school_period_id, mentor_at_school_period_id and finished_on values
-               of an existing training period" do
-        let!(:existing_period) { FactoryBot.create(:training_period) }
-        let(:started_on) { existing_period.started_on }
-        let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
-        let(:mentor_at_school_period_id) { existing_period.mentor_at_school_period_id }
-
-        subject { FactoryBot.build(:training_period, ect_at_school_period_id:, mentor_at_school_period_id:, started_on:) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(started_on: ["matches the start date of an existing period for trainee"])
-        end
-      end
-    end
 
     context "exactly one id of trainee present" do
       context "when ect_at_school_period_id and mentor_at_school_period_id are all nil" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'

--- a/spec/support/period_helpers.rb
+++ b/spec/support/period_helpers.rb
@@ -1,0 +1,38 @@
+module PeriodHelpers
+  class PeriodExamples
+    def self.period_examples
+      [
+        OpenStruct.new(
+          description: 'when the existing period contains the new one',
+          existing_period_range: 4.months.ago.to_date..1.month.ago.to_date,
+          new_period_range: 3.months.ago.to_date..2.months.ago.to_date,
+          expected_valid: false
+        ),
+        OpenStruct.new(
+          description: 'when the new period starts before the existing one has finished',
+          existing_period_range: 4.months.ago.to_date..2.months.ago.to_date,
+          new_period_range: 3.months.ago.to_date..1.month.ago.to_date,
+          expected_valid: false
+        ),
+        OpenStruct.new(
+          description: 'when the new period finishes after the existing one has started',
+          existing_period_range: 4.months.ago.to_date..2.months.ago.to_date,
+          new_period_range: 5.months.ago.to_date..3.months.ago.to_date,
+          expected_valid: false
+        ),
+        OpenStruct.new(
+          description: 'when the later period starts on the day the former one finishes',
+          existing_period_range: 4.months.ago.to_date..1.month.ago.to_date,
+          new_period_range: 1.month.ago.to_date..1.week.ago.to_date,
+          expected_valid: true
+        ),
+        OpenStruct.new(
+          description: 'when the periods are entirely separate',
+          existing_period_range: 4.months.ago.to_date..2.months.ago.to_date,
+          new_period_range: 1.month.ago.to_date..1.week.ago.to_date,
+          expected_valid: true
+        )
+      ]
+    end
+  end
+end


### PR DESCRIPTION
This PR adds some extra period validation, removes some duplicate validation and refactors plenty of tests.

## Period envelopment validation

Some periods of time belong to other periods. For example, a `MentorshipPeriod` exists between `ECTAtSchoolPeriod` and `MentorAtSchoolPeriod` - it shouldn't stretch beyond any point in time that isn't covered by both the `ECTAtSchoolPeriod` and `MentorAtSchoolPeriod`.

![Screenshot from 2024-09-26 16-54-51](https://github.com/user-attachments/assets/a3177d18-b207-46e5-9e03-64e5f76c2938)

The same 'containment' principle applies elsewhere too:

* an `InductionPeriod` must be enveloped by its corresponding `ECTAtSchoolPeriod`
* a `TrainingPeriod` for mentor training must be enveloped by its corresponding `MentorAtSchoolPeriod`
* a `TrainingPeriod` for ECT training must be enveloped by its corresponding `ECTAtSchoolPeriod`

Making this change made lots of tests fail, which is why the refactoring is part of this PR.

## Refactoring

The tests that broke because of the new validation were mainly because the factories don't pay attention to the scope of the 'parent' periods. We shouldn't really rely on factories to build the world so there's a little more setup. It might make sense to reintroduce something like ECF1's scenarios to handle these better.

To remove some duplication there is a list of common test cases in `PeriodHelpers::PeriodExamples`. They ensure that periods can:

* not overlap their siblings
* finish on the day their sibling starts (so there's no gap between periods)

## Removing unique time boundaries

The checks that ensure two periods that belong to the same thing can't start/finish at the same time have been removed as those checks are handled by the overlap tests already.

## Review suggestions

Probably worth going through commit by commit, paying most attention to 8623e8028bb70953f977c8e0534f6da39a78fb92
