### PR TITLE
Teacher search

### DIFF
--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -1,6 +1,8 @@
 class Teacher < ApplicationRecord
   TRN_FORMAT = %r{\A\d{7}\z}
 
+  self.ignored_columns = %i[search]
+
   # Associations
   has_many :ect_at_school_periods, inverse_of: :teacher
   has_many :mentor_at_school_periods, inverse_of: :teacher
@@ -15,4 +17,6 @@ class Teacher < ApplicationRecord
   validates :trn,
             format: { with: TRN_FORMAT, message: "TRN must be 7 numeric digits" },
             uniqueness: { message: 'TRN already exists', case_sensitive: false }
+
+  scope :search, ->(query_string) { where('teachers.search @@ websearch_to_tsquery(?)', query_string) }
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -6,7 +6,10 @@ class Teacher < ApplicationRecord
   has_many :mentor_at_school_periods, inverse_of: :teacher
 
   # Validations
-  validates :name,
+  validates :first_name,
+            presence: true
+
+  validates :last_name,
             presence: true
 
   validates :trn,

--- a/app/services/teachers/search.rb
+++ b/app/services/teachers/search.rb
@@ -1,0 +1,25 @@
+module Teachers
+  class Search
+    def initialize(query_string, filters: {})
+      @query_string = query_string
+
+      # TODO: no filters yet
+      @_filters = filters
+    end
+
+    def search
+      case
+      when @query_string.blank?
+        Teacher.all
+      when trns.any?
+        Teacher.where(trn: trns)
+      else
+        Teacher.search(@query_string)
+      end
+    end
+
+    def trns
+      @trns ||= @query_string.scan(%r(\d{7}))
+    end
+  end
+end

--- a/db/migrate/20240926161243_add_tsvector_column_to_teachers_for_searching.rb
+++ b/db/migrate/20240926161243_add_tsvector_column_to_teachers_for_searching.rb
@@ -1,0 +1,24 @@
+class AddTsvectorColumnToTeachersForSearching < ActiveRecord::Migration[7.2]
+  def change
+    enable_extension 'pg_trgm'
+
+    rename_column 'teachers', :name, :corrected_name
+
+    # rubocop:disable Rails/ReversibleMigration
+    change_column 'teachers', :corrected_name, :string, null: true
+    # rubocop:enable Rails/ReversibleMigration
+
+    change_table 'teachers', bulk: true do |t|
+      # rubocop:disable Rails/NotNullColumn
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+      # rubocop:enable Rails/NotNullColumn
+
+      tsvector_columns = %w[first_name last_name corrected_name].map { |col| "coalesce(#{col}, '')" }.join(" || ' ' || ")
+      t.tsvector :search, type: :tsvector, as: "to_tsvector('english', #{tsvector_columns})", stored: true
+    end
+
+    add_index :teachers, :search, using: :gin
+    add_index :teachers, %i[first_name last_name corrected_name], using: :gin, opclass: { first_name: :gin_trgm_ops, last_name: :gin_trgm_ops, corrected_name: :gin_trgm_ops }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_24_152526) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_26_161243) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
@@ -371,11 +372,16 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_24_152526) do
   end
 
   create_table "teachers", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "corrected_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "trn", null: false
-    t.index ["name"], name: "index_teachers_on_name"
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.virtual "search", type: :tsvector, as: "to_tsvector('english'::regconfig, (((((COALESCE(first_name, ''::character varying))::text || ' '::text) || (COALESCE(last_name, ''::character varying))::text) || ' '::text) || (COALESCE(corrected_name, ''::character varying))::text))", stored: true
+    t.index ["corrected_name"], name: "index_teachers_on_corrected_name"
+    t.index ["first_name", "last_name", "corrected_name"], name: "index_teachers_on_first_name_and_last_name_and_corrected_name", opclass: :gin_trgm_ops, using: :gin
+    t.index ["search"], name: "index_teachers_on_search", using: :gin
     t.index ["trn"], name: "index_teachers_on_trn", unique: true
   end
 

--- a/spec/factories/teacher_factory.rb
+++ b/spec/factories/teacher_factory.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory(:teacher) do
     sequence(:trn, 1_000_000)
-    name { [Faker::Name.name, Faker::Name.last_name].join(" ") }
+    first_name { Faker::Name.name }
+    last_name { Faker::Name.last_name }
+    corrected_name { [first_name, Faker::Name.middle_name, last_name].join(' ') }
   end
 end

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -30,8 +30,8 @@ describe Interval do
   end
 
   describe "scopes" do
-    let!(:teacher_id) { FactoryBot.create(:teacher, name: "Teacher One").id }
-    let!(:teacher_2_id) { FactoryBot.create(:teacher, name: "Teacher Two").id }
+    let!(:teacher_id) { FactoryBot.create(:teacher, first_name: "Teacher", last_name: "One").id }
+    let!(:teacher_2_id) { FactoryBot.create(:teacher, first_name: "Teacher", last_name: "Two").id }
     let!(:school_id) { FactoryBot.create(:school, urn: "1234567").id }
     let!(:period_1) { DummyMentor.create(teacher_id:, school_id:, started_on: '2023-01-01', finished_on: '2023-06-01') }
     let!(:period_2) { DummyMentor.create(teacher_id:, school_id:, started_on: '2023-07-01', finished_on: '2023-12-01') }

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -7,7 +7,8 @@ describe Teacher do
   describe "validations" do
     subject { FactoryBot.build(:teacher) }
 
-    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
     it { is_expected.to validate_uniqueness_of(:trn).with_message('TRN already exists').case_insensitive }
 
     describe "trn" do

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -25,4 +25,31 @@ describe Teacher do
       end
     end
   end
+
+  describe 'scopes' do
+    describe '#search' do
+      it "searches the 'search' column using a tsquery" do
+        expect(Teacher.search('Joey').to_sql).to end_with(%{WHERE (teachers.search @@ websearch_to_tsquery('Joey'))})
+      end
+
+      describe "matching" do
+        let!(:target) { FactoryBot.create(:teacher, first_name: "Malcolm", last_name: "Wilkerson", corrected_name: nil) }
+        let!(:other) { FactoryBot.create(:teacher, first_name: "Reese", last_name: "Wilkerson", corrected_name: nil) }
+
+        it "returns only the expected result" do
+          results = Teacher.search('Malcolm')
+
+          expect(results).to include(target)
+          expect(results).not_to include(other)
+        end
+
+        it "supports web search syntax" do
+          results = Teacher.search('Wilkerson -Reese')
+
+          expect(results).to include(target)
+          expect(results).not_to include(other)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe Teachers::Search do
+  describe 'dealing with search terms' do
+    subject { Teachers::Search.new(query_string) }
+
+    context 'when there are 7 digit numbers in the search string' do
+      before { allow(Teacher).to receive(:where).and_call_original }
+      let(:query_string) { 'the quick brown 1234567 jumped over the lazy 2345678' }
+
+      it 'searches for all present 7 digit numbers (TRNs)' do
+        subject.search
+
+        expect(Teacher).to have_received(:where).with(trn: %w[1234567 2345678])
+      end
+    end
+
+    context 'when the search string is blank' do
+      before { allow(Teacher).to receive(:all).and_call_original }
+
+      let(:query_string) { ' ' }
+
+      it 'applies no conditions and returns all teachers' do
+        subject.search
+
+        expect(Teacher).to have_received(:all).once.with(no_args)
+      end
+    end
+
+    context 'when the search string contains some text' do
+      before { allow(Teacher).to receive(:search).and_call_original }
+
+      let(:query_string) { 'Captain Scrummy' }
+
+      it 'initiates a full text search with the given search string' do
+        subject.search
+
+        expect(Teacher).to have_received(:search).once.with(query_string)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is some prep work for the upcoming addition of a teacher list for ABs. We will want to provide basic searching and filtering, and this change implenents searching.

* Searches that contain 7 digit numbers will search by TRN. If the search term contains multiple 7 digit numbers all will be returned.
* Blank searches will return all teachers, this will be the default state when someone navigates to the page
* Searches with strings of text will use PostgreSQL's full text indexing. For now this is [lexeme based](https://www.postgresql.org/docs/current/textsearch-intro.html), which is really fast. If we want to support matching when something _almost_ matches we can easily implement that too with [trigrams](https://en.wikipedia.org/wiki/Trigram) via [pg_tgrm](https://www.postgresql.org/docs/current/pgtrgm.html).

## Changes

- **Add search column for teachers**
- **Add search scope to Teacher model**
- **Add Teachers::Search class with basic searching**

## How it works

Under the hood, there's a new generated field that's ignored by Rails on the Teacher record called `search`.

If we pull it directly from the database we can see it looks like this:

```
ecf2_development=# select * from teachers where id = 1;
┌─[ RECORD 1 ]───┬──────────────────────────────────────────────────────────────────────────────────┐
│ id             │ 1                                                                                │
│ preferred_name │ Charita Konopelski Esq. Walter Feeney                                            │
│ created_at     │ 2024-09-27 15:38:07.436408                                                       │
│ updated_at     │ 2024-09-27 15:38:07.436408                                                       │
│ trn            │ 1000000                                                                          │
│ first_name     │ Charita Konopelski Esq.                                                          │
│ last_name      │ Feeney                                                                           │
│ search         │ 'charita':1 'esq':5 'esq.feeneycharita':3 'feeney':7 'konopelski':2,4 'walter':6 │
└────────────────┴──────────────────────────────────────────────────────────────────────────────────┘
```

It contains a [tsvector](https://www.postgresql.org/docs/current/textsearch-controls.html) which is used by the full text search for matching. The field is indexed which makes matching _really fast_ ([see this doc I wrote a few years ago](https://github.com/DFE-Digital/full-text-indexing-strategies)).

That allows us to convert our search string to a `tsquery` and match.

I'm using PostgreSQL's `websearch_to_tsvector` function here which gives us some nice stuff for free, like you can search how you might on Google. For example,`Bill or Ben` and records that match _either_ Bill or Ben are returned. Also you can prepend a `-` on a word to negate it, like `Flags -Paving`.

Most people won't notice this stuff and it'll just act like a normal search.

So, we can search like this:

```
ecf2_development=# select trn, preferred_name, first_name, last_name, search from teachers where teachers.search @@ websearch_to_tsquery('Charita');
┌─────────┬───────────────────────────────────────┬─────────────────────────┬───────────┬──────────────────────────────────────────────────────────────────────────────────┐
│   trn   │            preferred_name             │       first_name        │ last_name │                                      search                                      │
├─────────┼───────────────────────────────────────┼─────────────────────────┼───────────┼──────────────────────────────────────────────────────────────────────────────────┤
│ 1000000 │ Charita Konopelski Esq. Walter Feeney │ Charita Konopelski Esq. │ Feeney    │ 'charita':1 'esq':5 'esq.feeneycharita':3 'feeney':7 'konopelski':2,4 'walter':6 │
│ 1103501 │ Charita Legros Crona Jerde            │ Charita Legros          │ Jerde     │ 'charita':1 'crona':4 'jerd':5 'legro':3 'legrosjerdecharita':2                  │
│ 1104131 │ Charita Collier Thompson Mueller      │ Charita Collier         │ Mueller   │ 'charita':1 'collier':3 'colliermuellercharita':2 'mueller':5 'thompson':4       │
└─────────┴───────────────────────────────────────┴─────────────────────────┴───────────┴──────────────────────────────────────────────────────────────────────────────────┘
```

Or in Rails

```
ecf2(dev)> Teacher.search('Charita')
  Teacher Load (0.7ms)  SELECT "teachers"."id", "teachers"."preferred_name", "teachers"."created_at", "teachers"."updated_at", "teachers"."trn", "teachers"."first_name", "teachers"."last_name" FROM "teachers" WHERE (teachers.search @@ websearch_to_tsquery($1)) /* loading for pp */ LIMIT $2  [[nil, "Charita"], ["LIMIT", 11]]
=>
[#<Teacher:0x00007f32b00a8068
  id: 1,
  preferred_name: "Charita Konopelski Esq. Walter Feeney",
  created_at: "2024-09-27 15:38:07.436408000 +0000",
  updated_at: "2024-09-27 15:38:07.436408000 +0000",
  trn: "1000000",
  first_name: "Charita Konopelski Esq.",
  last_name: "Feeney">,
 #<Teacher:0x00007f32b03be608
  id: 3512,
  preferred_name: "Charita Legros Crona Jerde",
  created_at: "2024-09-27 16:10:01.370485000 +0000",
  updated_at: "2024-09-27 16:10:01.370485000 +0000",
  trn: "1103501",
  first_name: "Charita Legros",
  last_name: "Jerde">,
 #<Teacher:0x00007f32b03bdfc8
  id: 4142,
  preferred_name: "Charita Collier Thompson Mueller",
  created_at: "2024-09-27 16:10:06.374944000 +0000",
  updated_at: "2024-09-27 16:10:06.374944000 +0000",
  trn: "1104131",
  first_name: "Charita Collier",
  last_name: "Mueller">]
ecf2(dev)>
```

And under the hood it's all indexed and fast.

```
ecf2_development=# explain select trn, preferred_name, first_name, last_name, search from teachers where teachers.search @@ websearch_to_tsquery('Charita');
┌────────────────────────────────────────────────────────────────────────────────────────┐
│                                       QUERY PLAN                                       │
├────────────────────────────────────────────────────────────────────────────────────────┤
│ Bitmap Heap Scan on teachers  (cost=13.09..24.53 rows=3 width=153)                     │
│   Recheck Cond: (search @@ websearch_to_tsquery('Charita'::text))                      │
│   ->  Bitmap Index Scan on index_teachers_on_search  (cost=0.00..13.09 rows=3 width=0) │
│         Index Cond: (search @@ websearch_to_tsquery('Charita'::text))                  │
└────────────────────────────────────────────────────────────────────────────────────────┘
```
