### PR TITLE
Appropriate body lowfi UI

### DIFF
--- a/app/controllers/appropriate_bodies/claim_an_ect/check_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/check_ect_controller.rb
@@ -15,7 +15,7 @@ module AppropriateBodies
           .new(appropriate_body: @appropriate_body, pending_induction_submission: @pending_induction_submission)
           .confirm_info_correct(confirmed?)
 
-        if @pending_induction_submission.save(context: :confirming_ect)
+        if @pending_induction_submission.save(context: :check_ect)
           redirect_to(edit_ab_claim_an_ect_register_path(@pending_induction_submission))
         else
           render :edit

--- a/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
@@ -6,13 +6,16 @@ module AppropriateBodies
       end
 
       def create
-        @pending_induction_submission = PendingInductionSubmission.new(pending_induction_submission_params)
+        @pending_induction_submission = PendingInductionSubmission.new(
+          **pending_induction_submission_params,
+          **pending_induction_submission_attributes
+        )
 
         AppropriateBodies::ClaimAnECT::FindECT
           .new(appropriate_body: @appropriate_body, pending_induction_submission: @pending_induction_submission)
           .import_from_trs
 
-        if @pending_induction_submission.save
+        if @pending_induction_submission.save(context: :find_ect)
           redirect_to(edit_ab_claim_an_ect_check_path(@pending_induction_submission))
         else
           render(:new)
@@ -27,6 +30,10 @@ module AppropriateBodies
 
       def pending_induction_submission_params
         params.require(:pending_induction_submission).permit(:trn, :date_of_birth)
+      end
+
+      def pending_induction_submission_attributes
+        { appropriate_body_id: @appropriate_body.id }
       end
     end
   end

--- a/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
@@ -1,0 +1,43 @@
+module AppropriateBodies
+  module Teachers
+    class ReleaseECTController < AppropriateBodiesController
+      def new
+        @teacher = Teacher.find(params[:ab_teacher_id])
+
+        @pending_induction_submission = PendingInductionSubmission.new
+      end
+
+      def create
+        @teacher = Teacher.find(params[:ab_teacher_id])
+        @pending_induction_submission = PendingInductionSubmission.new(
+          **pending_induction_submission_params,
+          **pending_induction_submission_attributes
+        )
+
+        release_ect = AppropriateBodies::ReleaseECT.new(appropriate_body: @appropriate_body, pending_induction_submission: @pending_induction_submission)
+
+        PendingInductionSubmission.transaction do
+          if @pending_induction_submission.save(context: :record_period) && release_ect.release!
+            redirect_to ab_teacher_release_ect_path(@teacher)
+          else
+            render :new
+          end
+        end
+      end
+
+      def show
+        @teacher = Teacher.find(params[:ab_teacher_id])
+      end
+
+    private
+
+      def pending_induction_submission_params
+        params.require(:pending_induction_submission).permit(:finished_on, :number_of_terms)
+      end
+
+      def pending_induction_submission_attributes
+        { appropriate_body_id: @appropriate_body.id, trn: @teacher.trn }
+      end
+    end
+  end
+end

--- a/app/controllers/appropriate_bodies/teachers_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers_controller.rb
@@ -1,0 +1,9 @@
+module AppropriateBodies
+  class TeachersController < AppropriateBodiesController
+    def show
+      # FIXME: find within the scope of the current AB
+
+      @teacher = Teacher.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/appropriate_bodies_controller.rb
+++ b/app/controllers/appropriate_bodies_controller.rb
@@ -4,6 +4,12 @@ class AppropriateBodiesController < ApplicationController
   before_action :set_appropriate_body
   layout "full", only: :show
 
+  def show
+    # FIXME: find within the scope of the current AB
+
+    @teachers = Teachers::Search.new(params[:q]).search
+  end
+
 private
 
   def set_appropriate_body

--- a/app/controllers/appropriate_bodies_controller.rb
+++ b/app/controllers/appropriate_bodies_controller.rb
@@ -2,6 +2,7 @@ class AppropriateBodiesController < ApplicationController
   include Authorisation
 
   before_action :set_appropriate_body
+  layout "full", only: :show
 
 private
 

--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -12,9 +12,13 @@ class PendingInductionSubmission < ApplicationRecord
   belongs_to :appropriate_body
 
   # Validations
+  validates :appropriate_body_id,
+            presence: { message: "Select an appropriate body" }
+
   validates :trn,
             presence: { message: "Enter a TRN" },
-            format: { with: Teacher::TRN_FORMAT, message: "TRN must be 7 numeric digits" }
+            format: { with: Teacher::TRN_FORMAT, message: "TRN must be 7 numeric digits" },
+            on: :find_ect
 
   validates :establishment_id,
             format: { with: /\A\d{4}\/\d{3}\z/, message: "Enter an establishment ID in the format 1234/567" },
@@ -29,19 +33,24 @@ class PendingInductionSubmission < ApplicationRecord
             presence: { message: "Enter a start date" },
             on: :register_ect
 
-  validates :date_of_birth,
-            presence: { message: "Enter a date of birth" },
-            inclusion: {
-              in: 100.years.ago.to_date..18.years.ago.to_date,
-              message: "Teacher must be between 18 and 100 years old",
-            }
+  validates :finished_on,
+            presence: { message: "Enter a finish date" },
+            on: :record_period
 
   validates :number_of_terms,
             inclusion: { in: 0..16,
                          message: "Terms must be between 0 and 16" },
             on: :record_period
 
+  validates :date_of_birth,
+            presence: { message: "Enter a date of birth" },
+            inclusion: {
+              in: 100.years.ago.to_date..18.years.ago.to_date,
+              message: "Teacher must be between 18 and 100 years old",
+            },
+            on: :find_ect
+
   validates :confirmed,
             acceptance: { message: "Confirm if these details are correct or try your search again" },
-            on: :confirming_ect
+            on: :check_ect
 end

--- a/app/services/appropriate_bodies/claim_an_ect/find_ect.rb
+++ b/app/services/appropriate_bodies/claim_an_ect/find_ect.rb
@@ -18,7 +18,7 @@ module AppropriateBodies
         return pending_induction_submission unless pending_induction_submission.valid?
 
         pending_induction_submission.assign_attributes(
-          appropriate_body:,
+          appropriate_body: @appropriate_body,
           **find_matching_record_in_trs
         )
 

--- a/app/services/appropriate_bodies/release_ect.rb
+++ b/app/services/appropriate_bodies/release_ect.rb
@@ -1,0 +1,15 @@
+module AppropriateBodies
+  class ReleaseECT
+    def initialize(appropriate_body:, pending_induction_submission:)
+      @appropriate_body = appropriate_body
+      @pending_induction_submission = pending_induction_submission
+    end
+
+    def release!
+      # FIXME: implement a proper release process here,
+      #        it probably needs to just close the current
+      #        open induction portal and write an event
+      true
+    end
+  end
+end

--- a/app/services/teachers/name.rb
+++ b/app/services/teachers/name.rb
@@ -1,0 +1,20 @@
+class Teachers::Name
+  attr_reader :teacher
+
+  def initialize(teacher)
+    @teacher = teacher
+  end
+
+  def full_name
+    teacher.corrected_name || first_name_plus_last_name
+  end
+
+private
+
+  # this isn't really the _right_ thing to do but given
+  # we only receive separate first and last names from TRS
+  # we're left with little option
+  def first_name_plus_last_name
+    %(#{teacher.first_name} #{teacher.last_name})
+  end
+end

--- a/app/views/appropriate_bodies/claim_an_ect/register_ect/show.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/register_ect/show.html.erb
@@ -1,7 +1,6 @@
 <% page_data(
   title: "#{@pending_induction_submission.trs_first_name} #{@pending_induction_submission.trs_last_name} is registered",
-  header: false,
-  error: @pending_induction_submission.errors.present?)
+  header: false)
 %>
 
 

--- a/app/views/appropriate_bodies/show.html.erb
+++ b/app/views/appropriate_bodies/show.html.erb
@@ -1,3 +1,25 @@
-<% page_data(title: "Some appropriate body", error: false) %>
+<% page_data(title: @appropriate_body.name, error: false) %>
 
-<%= govuk_button_link_to("Register a new early career teacher", new_ab_claim_an_ect_find_path, secondary: true) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= govuk_button_link_to("Register a new early career teacher", new_ab_claim_an_ect_find_path, secondary: true) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">Search</h2>
+
+    <mark class="govuk-body">Add search and filter stuff here.</mark>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <ul class="govuk-list govuk-list--bullet">
+      <% @teachers.all.each do |teacher| %>
+        <%= tag.li do %>
+          <%= govuk_link_to("#{teacher.first_name} #{teacher.last_name}", ab_teacher_path(teacher)) %>
+        <% end %>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/appropriate_bodies/teachers/release_ect/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/release_ect/new.html.erb
@@ -1,0 +1,23 @@
+<% page_data(title: "Release #{Teachers::Name.new(@teacher).full_name}", error: false) %>
+
+<%= form_with(model: @pending_induction_submission, url: ab_teacher_release_ect_path(@teacher), method: 'post') do |form| %>
+  <%= form.govuk_error_summary %>
+
+  <%=
+    form.govuk_date_field :finished_on,
+      legend: {
+        text: "When did #{Teachers::Name.new(@teacher).full_name} finish their induction with you?"
+      }
+  %>
+
+  <%=
+    form.govuk_number_field :number_of_terms,
+      width: 4,
+      label: {
+        size: 'm',
+        text: "How many terms of induction did #{Teachers::Name.new(@teacher).full_name} spend with you?"
+      }
+    %>
+
+  <%= form.govuk_submit %>
+<% end %>

--- a/app/views/appropriate_bodies/teachers/release_ect/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/release_ect/show.html.erb
@@ -1,0 +1,10 @@
+<% page_data(
+  title: "#{Teachers::Name.new(@teacher).full_name} has been released",
+  header: false)
+%>
+
+<%=
+  govuk_panel(title_text: "Success", text: "#{Teachers::Name.new(@teacher).full_name} has been released")
+%>
+
+<%= govuk_button_link_to("Return to the homepage", ab_path, secondary: true) %>

--- a/app/views/appropriate_bodies/teachers/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/show.html.erb
@@ -1,6 +1,9 @@
 <% page_data(title: Teachers::Name.new(@teacher).full_name, error: false) %>
 
-<%= govuk_button_link_to("Record induction outcome", "#", secondary: true) %>
+<div class="govuk-button-group">
+  <%= govuk_button_link_to("Release ECT", new_ab_teacher_release_ect_path(@teacher), secondary: true) %>
+  <%= govuk_button_link_to("Record induction outcome", "#", secondary: true) %>
+</div>
 
 <h2 class="govuk-heading-m">Early career teacher<h2>
 

--- a/app/views/appropriate_bodies/teachers/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/show.html.erb
@@ -1,0 +1,28 @@
+<% page_data(title: Teachers::Name.new(@teacher).full_name, error: false) %>
+
+<%= govuk_button_link_to("Record induction outcome", "#", secondary: true) %>
+
+<h2 class="govuk-heading-m">Early career teacher<h2>
+
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "Teacher record number")
+      row.with_value(text: @teacher.trn)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "First name")
+      row.with_value(text: @teacher.first_name)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Last name")
+      row.with_value(text: @teacher.last_name)
+    end
+  end
+%>
+
+<h2 class="govuk-heading-m">Induction history<h2>
+
+<mark class="govuk-body">Add this later.</mark>

--- a/app/views/layouts/full.html.erb
+++ b/app/views/layouts/full.html.erb
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <%= render partial: "layouts/shared/head" %>
+
+  <body class="govuk-template__body">
+    <%= render partial: "layouts/shared/js_enabled" %>
+
+    <%= govuk_skip_link %>
+    <%= govuk_header(full_width_border: true, html_attributes: { class: [environment_specific_header_colour_class] }) %>
+    <%= govuk_service_navigation(service_name: "Register early career teachers") do |service_navigation| %>
+      <%= service_navigation.with_navigation_item(text: "Sign out", href: sign_out_path) if authenticated? %>
+    <% end %>
+
+    <div class="govuk-width-container">
+      <%= environment_specific_phase_banner %>
+
+      <main class="govuk-main-wrapper" id="main-content" role="main">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <%= yield(:page_header) %>
+          </div>
+        </div>
+
+        <%= yield %>
+      </main>
+    </div>
+
+    <%= govuk_footer %>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,10 @@ Rails.application.routes.draw do
 
   resource :appropriate_bodies, only: %i[show], path: 'appropriate-body', as: 'ab' do
     collection do
-      resources :teachers, only: %i[show], controller: 'appropriate_bodies/teachers', as: 'ab_teachers'
+      resources :teachers, only: %i[show], controller: 'appropriate_bodies/teachers', as: 'ab_teachers' do
+        resource :release_ect, only: %i[new create show], path: 'release', controller: 'appropriate_bodies/teachers/release_ect'
+        resource :record_outcome, only: %i[new create show], path: 'record-outcome', controller: 'appropriate_bodies/teachers/release_ect'
+      end
     end
     namespace :claim_an_ect, path: 'claim-an-ect' do
       resource :find_ect, only: %i[new create], path: 'find-ect', controller: '/appropriate_bodies/claim_an_ect/find_ect', as: 'find'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,9 @@ Rails.application.routes.draw do
   end
 
   resource :appropriate_bodies, only: %i[show], path: 'appropriate-body', as: 'ab' do
+    collection do
+      resources :teachers, only: %i[show], controller: 'appropriate_bodies/teachers', as: 'ab_teachers'
+    end
     namespace :claim_an_ect, path: 'claim-an-ect' do
       resource :find_ect, only: %i[new create], path: 'find-ect', controller: '/appropriate_bodies/claim_an_ect/find_ect', as: 'find'
       resources :check_ect, only: %i[edit update], path: 'check-ect', controller: '/appropriate_bodies/claim_an_ect/check_ect', as: 'check'

--- a/spec/factories/pending_induction_submission_factory.rb
+++ b/spec/factories/pending_induction_submission_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory(:pending_induction_submission) do
+    association :appropriate_body
     sequence(:trn, 3_000_000)
     date_of_birth { Faker::Date.between(from: 80.years.ago, to: 20.years.ago) }
     trs_first_name { Faker::Name.first_name }

--- a/spec/models/pending_induction_submission_spec.rb
+++ b/spec/models/pending_induction_submission_spec.rb
@@ -9,7 +9,7 @@ describe PendingInductionSubmission do
 
   describe "validation" do
     describe "trn" do
-      it { is_expected.to validate_presence_of(:trn).with_message("Enter a TRN") }
+      it { is_expected.to validate_presence_of(:trn).on(:find_ect).with_message("Enter a TRN") }
 
       context "when the string contains 7 numeric digits" do
         %w[0000001 9999999].each do |value|
@@ -19,15 +19,15 @@ describe PendingInductionSubmission do
 
       context "when the string contains something other than 7 numeric digits" do
         %w[123456 12345678 ONE4567 123456!].each do |value|
-          it { is_expected.not_to allow_value(value).for(:trn) }
+          it { is_expected.not_to allow_value(value).for(:trn).on(:find_ect) }
         end
       end
     end
 
     describe "date_of_birth" do
-      it { is_expected.to validate_presence_of(:date_of_birth).with_message("Enter a date of birth") }
+      it { is_expected.to validate_presence_of(:date_of_birth).with_message("Enter a date of birth").on(:find_ect) }
 
-      it { is_expected.to validate_inclusion_of(:date_of_birth).in_range(100.years.ago.to_date..18.years.ago.to_date).with_message("Teacher must be between 18 and 100 years old") }
+      it { is_expected.to validate_inclusion_of(:date_of_birth).in_range(100.years.ago.to_date..18.years.ago.to_date).on(:find_ect).with_message("Teacher must be between 18 and 100 years old") }
     end
 
     describe "establishment_id" do
@@ -35,13 +35,13 @@ describe PendingInductionSubmission do
 
       describe "valid" do
         ["1111/111", "9999/999"].each do |id|
-          it { is_expected.to allow_value(id).for(:establishment_id) }
+          it { is_expected.to allow_value(id).for(:establishment_id).on(:find_ect) }
         end
       end
 
       describe "invalid" do
         ["111/1111", "AAAA/BBB", "1234/12345"].each do |id|
-          it { is_expected.not_to allow_value(id).for(:establishment_id).with_message("Enter an establishment ID in the format 1234/567") }
+          it { is_expected.not_to allow_value(id).for(:establishment_id).on(:find_ect).with_message("Enter an establishment ID in the format 1234/567") }
         end
       end
     end
@@ -55,7 +55,7 @@ describe PendingInductionSubmission do
     end
 
     describe "confirmed" do
-      it { is_expected.to validate_acceptance_of(:confirmed).on(:confirming_ect).with_message("Confirm if these details are correct or try your search again") }
+      it { is_expected.to validate_acceptance_of(:confirmed).on(:check_ect).with_message("Confirm if these details are correct or try your search again") }
     end
   end
 end

--- a/spec/services/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::CheckECT do
       end
 
       it "results in the pending_induction_submission being valid" do
-        expect(subject.pending_induction_submission).to be_valid(:confirming_ect)
+        expect(subject.pending_induction_submission).to be_valid(:check_ect)
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::CheckECT do
       end
 
       it "results in the pending_induction_submission being invalid" do
-        expect(subject.pending_induction_submission).to be_invalid(:confirming_ect)
+        expect(subject.pending_induction_submission).to be_invalid(:check_ect)
       end
     end
   end

--- a/spec/services/teachers/name_spec.rb
+++ b/spec/services/teachers/name_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe Teachers::Name do
+  describe '#full_name' do
+    subject { Teachers::Name.new(teacher) }
+
+    context 'when a corrected_name is set' do
+      let(:teacher) { FactoryBot.build(:teacher) }
+
+      it 'returns the corrected name' do
+        expect(teacher.corrected_name).to be_present
+        expect(subject.full_name).to eql(teacher.corrected_name)
+      end
+    end
+
+    context 'when no corrected_name is set' do
+      let(:teacher) { FactoryBot.build(:teacher, corrected_name: nil) }
+
+      it 'returns the first name followed by the last name' do
+        expect(subject.full_name).to eql(%(#{teacher.first_name} #{teacher.last_name}))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This add some very low-fi pages, controllers and service objects that are intended to be refined later.

It gives us a pattern to reuse for the 'change induction programme' and 'complete induction' too (and maybe extend if we get round to it).

| AB home page |Viewing an ECT as an AB | Releasing an ECT | ECT released| 
| ------------- | ------ | ------ | ------ |
| ![Screenshot from 2024-10-02 10-21-40](https://github.com/user-attachments/assets/0ba8cfb1-fb78-4356-92a8-c289e070c8d2) | ![Screenshot from 2024-10-02 10-21-46](https://github.com/user-attachments/assets/e60b1f94-4f56-4ec7-9137-b0f2df0e3c9c) | ![Screenshot from 2024-10-02 10-22-07](https://github.com/user-attachments/assets/5f592390-5a44-4207-8538-4244fd93009e) | ![Screenshot from 2024-10-02 10-22-14](https://github.com/user-attachments/assets/d5aa19f1-75e6-49b2-b351-2ea3fd6ae561) |

