### PR TITLE
Refine logic to determine funding eligibility of schools

### DIFF
--- a/app/services/gias/school_row.rb
+++ b/app/services/gias/school_row.rb
@@ -88,8 +88,12 @@ module GIAS
       @funding_eligibility ||= determine_funding_eligibility
     end
 
+    def independent_school_type?
+      @independent_school_type ||= GIAS::Types::INDEPENDENT_SCHOOLS_TYPES.include?(type_name)
+    end
+
     def in_england
-      @in_england ||= data.fetch("DistrictAdministrative (code)").to_s.match?(/^([Ee]|9999)/)
+      @in_england ||= GIAS::Types::IN_ENGLAND_TYPES.include?(type_name)
     end
 
     alias_method :in_england?, :in_england
@@ -155,8 +159,8 @@ module GIAS
   private
 
     def determine_funding_eligibility
-      return :eligible_for_fip if open? && in_england? && (eligible_type? || section_41_approved?)
-      return :eligible_for_cip if open? && cip_only_type?
+      return :eligible_for_fip if open? && in_england? && (eligible_type? || (independent_school_type? && section_41_approved?))
+      return :eligible_for_cip if open? && cip_only_type? && !section_41_approved?
 
       :ineligible
     end

--- a/app/services/gias/types.rb
+++ b/app/services/gias/types.rb
@@ -3,45 +3,45 @@
 module GIAS
   class Types
     ALL_TYPES = [
-      "Community school",
-      "Voluntary aided school",
-      "Voluntary controlled school",
-      "Foundation school",
-      "City technology college",
-      "Community special school",
-      "Non-maintained special school",
-      "Other independent special school",
-      "Other independent school",
-      "Foundation special school",
-      "Pupil referral unit",
-      "Local authority nursery school",
-      "Further education",
-      "Secure units",
-      "Offshore schools",
-      "Service children's education",
-      "Miscellaneous",
-      "Academy sponsor led",
-      "Higher education institutions",
-      "Welsh establishment",
-      "Sixth form centres",
-      "Special post 16 institution",
-      "Academy special sponsor led",
-      "Academy converter",
-      "Free schools",
-      "Free schools special",
-      "British schools overseas",
-      "Free schools alternative provision",
-      "Free schools 16 to 19",
-      "University technical college",
-      "Studio schools",
+      "Academy 16 to 19 sponsor led",
+      "Academy 16-19 converter",
       "Academy alternative provision converter",
       "Academy alternative provision sponsor led",
-      "Academy special converter",
-      "Academy 16-19 converter",
-      "Academy 16 to 19 sponsor led",
-      "Online provider",
-      "Institution funded by other government department",
+      "Academy converter",
       "Academy secure 16 to 19",
+      "Academy special converter",
+      "Academy special sponsor led",
+      "Academy sponsor led",
+      "British schools overseas",
+      "City technology college",
+      "Community school",
+      "Community special school",
+      "Foundation school",
+      "Foundation special school",
+      "Free schools 16 to 19",
+      "Free schools alternative provision",
+      "Free schools special",
+      "Free schools",
+      "Further education",
+      "Higher education institutions",
+      "Institution funded by other government department",
+      "Local authority nursery school",
+      "Miscellaneous",
+      "Non-maintained special school",
+      "Offshore schools",
+      "Online provider",
+      "Other independent school",
+      "Other independent special school",
+      "Pupil referral unit",
+      "Secure units",
+      "Service children's education",
+      "Sixth form centres",
+      "Special post 16 institution",
+      "Studio schools",
+      "University technical college",
+      "Voluntary aided school",
+      "Voluntary controlled school",
+      "Welsh establishment",
     ].freeze
 
     CIP_ONLY_TYPES = [
@@ -57,7 +57,7 @@ module GIAS
       "British schools overseas"
     ].freeze
 
-    ELIGIBLE_TYPES = ALL_TYPES - [
+    NOT_ELIGIBLE_TYPES = [
       "Other independent special school",
       "Other independent school",
       "Secure units",
@@ -71,9 +71,20 @@ module GIAS
       "Institution funded by other government department"
     ].freeze
 
+    ELIGIBLE_TYPES = ALL_TYPES - NOT_ELIGIBLE_TYPES
+
     INDEPENDENT_SCHOOLS_TYPES = [
       "Other independent special school",
       "Other independent school"
     ].freeze
+
+    NOT_IN_ENGLAND_TYPES = [
+      "British schools overseas",
+      "Offshore schools",
+      "Service children's education",
+      "Welsh establishment",
+    ].freeze
+
+    IN_ENGLAND_TYPES = (ALL_TYPES - NOT_IN_ENGLAND_TYPES).freeze
   end
 end

--- a/spec/factories/gias/school_factory.rb
+++ b/spec/factories/gias/school_factory.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     eligible_for_registration
     eligible_for_fip
     induction_eligible
+    not_section_41
 
     local_authority_code { Faker::Number.within(range: 1..999) }
     name { Faker::Educator.primary_school + " (#{urn})" }
@@ -17,9 +18,9 @@ FactoryBot.define do
 
       if [true, false].sample
         eligible_type
-        not_section_41
       else
         not_eligible_type
+        independent_school_type
         section_41
       end
     end
@@ -27,6 +28,7 @@ FactoryBot.define do
     # cip_only
     trait(:cip_only) do
       cip_only_type
+      not_section_41
       [true, false].sample ? eligible_for_cip : funding_ineligible
     end
 
@@ -79,12 +81,12 @@ FactoryBot.define do
     # location
     trait(:in_england) do
       in_england { true }
-      administrative_district_name { "London" }
+      type_name { GIAS::Types::IN_ENGLAND_TYPES.sample }
     end
 
     trait(:not_in_england) do
       in_england { false }
-      administrative_district_name { "Cardiff" }
+      type_name { GIAS::Types::NOT_IN_ENGLAND_TYPES.sample }
     end
 
     # type code
@@ -101,7 +103,11 @@ FactoryBot.define do
     end
 
     trait(:not_eligible_type) do
-      type_name { (GIAS::Types::ALL_TYPES - GIAS::Types::ELIGIBLE_TYPES).sample }
+      type_name { GIAS::Types::NOT_ELIGIBLE_TYPES.sample }
+    end
+
+    trait(:independent_school_type) do
+      type_name { GIAS::Types::INDEPENDENT_SCHOOLS_TYPES.sample }
     end
   end
 end


### PR DESCRIPTION
This PR contains two changes: 
- Fine tune the way we classify schools for funding eligibility.
- Determine if a school is or not in England based on its type instead of its administrative code.