### PR TITLE
Remove require 'rails_helper' from specs

### DIFF
--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Admin" do
   include UserHelper
   # TODO: This test should be replaced with something meaningful.

--- a/spec/features/appropriate_bodies/claim_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/claim_an_ect_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'Claiming an ECT' do
   include_context 'fake_trs_api_client'
 

--- a/spec/forms/admin/roles_form_spec.rb
+++ b/spec/forms/admin/roles_form_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Admin::RolesForm, type: :model do
   let(:user) { FactoryBot.create(:user) }
   let(:appropriate_bodies) { FactoryBot.build_list(:appropriate_body, 3) }

--- a/spec/forms/sessions/otp_sign_in_form_spec.rb
+++ b/spec/forms/sessions/otp_sign_in_form_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Sessions::OTPSignInForm, type: :model do
   it { is_expected.to validate_presence_of(:email).with_message("Enter your email address") }
   it { is_expected.to validate_presence_of(:code).on(:verify).with_message("Enter the 6-digit code from the email") }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ApplicationHelper, type: :helper do
   describe "#page_data" do
     it "sets the title to the provided value" do

--- a/spec/helpers/appropriate_body_helper_spec.rb
+++ b/spec/helpers/appropriate_body_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe AppropriateBodyHelper, type: 'helper' do
   describe "#induction_programme_choices" do
     it "returns an array of InductionProgrammeChoice" do

--- a/spec/helpers/environment_helper_spec.rb
+++ b/spec/helpers/environment_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'ostruct'
 
 RSpec.describe EnvironmentHelper, type: :helper do

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 # Specs in this file have access to a helper object that includes
 # the PagesHelper. For example:
 #

--- a/spec/jobs/begin_ect_induction_job_spec.rb
+++ b/spec/jobs/begin_ect_induction_job_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe BeginECTInductionJob, type: :job do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:teacher_id) { teacher.id }

--- a/spec/lib/TRS/api_client_spec.rb
+++ b/spec/lib/TRS/api_client_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe TRS::APIClient do
   let(:client) { described_class.new }
   let(:trn) { '1234567' }

--- a/spec/lib/TRS/teacher_spec.rb
+++ b/spec/lib/TRS/teacher_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe TRS::Teacher do
   let(:data) do
     {

--- a/spec/lib/colourize_spec.rb
+++ b/spec/lib/colourize_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Colourize do
   describe ".text" do
     Colourize::COLOURS.each_key do |key|

--- a/spec/mailers/example_mailer_spec.rb
+++ b/spec/mailers/example_mailer_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe ExampleMailer, type: :mailer do
   describe "hello_world" do
     let(:from) { "from@example.com" }

--- a/spec/mailers/otp_mailer_spec.rb
+++ b/spec/mailers/otp_mailer_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe OTPMailer, type: :mailer do
   describe "otp_code_email" do
     let(:from) { "from@example.com" }

--- a/spec/migration/legacy_data_importer_spec.rb
+++ b/spec/migration/legacy_data_importer_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe LegacyDataImporter do
   include ActiveJob::TestHelper
 

--- a/spec/models/appropriate_body_role_spec.rb
+++ b/spec/models/appropriate_body_role_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe AppropriateBodyRole, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:user) }

--- a/spec/models/dfe_role_spec.rb
+++ b/spec/models/dfe_role_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe DfERole, type: :model do
   it "defines role precendence" do
     expect(described_class::ROLE_PRECEDENCE).to eq(%w[super_admin finance admin])

--- a/spec/models/pending_induction_submission_spec.rb
+++ b/spec/models/pending_induction_submission_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe PendingInductionSubmission do
   it { is_expected.to be_a_kind_of(Interval) }
 

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Admin", type: :request do
   describe "GET /admin" do
     it "redirects to sign-in" do

--- a/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT' do
   include AuthHelper
   let(:appropriate_body) { user.appropriate_bodies.first }

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
   include_context 'fake_trs_api_client'
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
   let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:page_heading) { "Tell us about" }

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Pages", type: :request do
   describe "GET /" do
     it "returns http success" do

--- a/spec/services/admin/access_spec.rb
+++ b/spec/services/admin/access_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe Admin::Access do
   subject { Admin::Access.new(user) }
 

--- a/spec/services/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe AppropriateBodies::ClaimAnECT::CheckECT do
   let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
   let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }

--- a/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
   describe "#initialize" do
     let(:appropriate_body) { FactoryBot.build(:appropriate_body) }

--- a/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }

--- a/spec/services/sessions/one_time_password_spec.rb
+++ b/spec/services/sessions/one_time_password_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Sessions::OneTimePassword do
   let(:user) { FactoryBot.create(:user) }
   subject(:service) { Sessions::OneTimePassword.new(user:) }

--- a/spec/services/sessions/session_manager_spec.rb
+++ b/spec/services/sessions/session_manager_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Sessions::SessionManager do
   let(:session) { HashWithIndifferentAccess.new }
   let(:email) { "eric@example.com" }

--- a/spec/services/teachers/name_spec.rb
+++ b/spec/services/teachers/name_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe Teachers::Name do
   describe '#full_name' do
     subject { Teachers::Name.new(teacher) }

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe Teachers::Search do
   describe 'dealing with search terms' do
     subject { Teachers::Search.new(query_string) }

--- a/spec/validators/notify_email_validator_spec.rb
+++ b/spec/validators/notify_email_validator_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe NotifyEmailValidator do
   # Test cases from https://github.com/alphagov/notifications-utils/blob/2432e1881cf7a5005a8d69c2ddc1597add96acc3/tests/test_recipient_validation.py
   # This file lifted from ECF1

--- a/spec/views/pages/home.html.erb_spec.rb
+++ b/spec/views/pages/home.html.erb_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "pages/home.html.erb", type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
We're already requiring it in .rspec so don't need to do it again 🤦
