### PR TITLE
Add low-fi record induction outcome

### DIFF
--- a/app/controllers/appropriate_bodies/teachers/record_outcome_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_outcome_controller.rb
@@ -1,0 +1,43 @@
+module AppropriateBodies
+  module Teachers
+    class RecordOutcomeController < AppropriateBodiesController
+      def new
+        @teacher = Teacher.find(params[:ab_teacher_id])
+
+        @pending_induction_submission = PendingInductionSubmission.new
+      end
+
+      def create
+        @teacher = Teacher.find(params[:ab_teacher_id])
+        @pending_induction_submission = PendingInductionSubmission.new(
+          **pending_induction_submission_params,
+          **pending_induction_submission_attributes
+        )
+
+        record_outcome = AppropriateBodies::RecordOutcome.new(appropriate_body: @appropriate_body, pending_induction_submission: @pending_induction_submission)
+
+        PendingInductionSubmission.transaction do
+          if @pending_induction_submission.save(context: :record_outcome) && record_outcome.record_outcome!
+            redirect_to ab_teacher_record_outcome_path(@teacher)
+          else
+            render :new
+          end
+        end
+      end
+
+      def show
+        @teacher = Teacher.find(params[:ab_teacher_id])
+      end
+
+    private
+
+      def pending_induction_submission_params
+        params.require(:pending_induction_submission).permit(:finished_on, :number_of_terms, :outcome)
+      end
+
+      def pending_induction_submission_attributes
+        { appropriate_body_id: @appropriate_body.id, trn: @teacher.trn }
+      end
+    end
+  end
+end

--- a/app/helpers/appropriate_body_helper.rb
+++ b/app/helpers/appropriate_body_helper.rb
@@ -1,5 +1,6 @@
 module AppropriateBodyHelper
   InductionProgrammeChoice = Struct.new(:identifier, :name)
+  InductionOutcomeChoice = Struct.new(:identifier, :name)
 
   def induction_programme_choices
     # FIXME: the names here are currently the ones we use internally, they
@@ -9,6 +10,13 @@ module AppropriateBodyHelper
       InductionProgrammeChoice.new(identifier: 'cip', name: 'Core induction programme'),
       InductionProgrammeChoice.new(identifier: 'fip', name: 'Full induction programme'),
       InductionProgrammeChoice.new(identifier: 'diy', name: 'Do it yourself')
+    ]
+  end
+
+  def induction_outcome_choices
+    [
+      InductionProgrammeChoice.new(identifier: 'pass', name: 'Passed'),
+      InductionProgrammeChoice.new(identifier: 'fail', name: 'Failed'),
     ]
   end
 

--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -8,6 +8,8 @@ class PendingInductionSubmission < ApplicationRecord
 
   attribute :confirmed
 
+  enum :outcome, { pass: "pass", fail: "fail" }
+
   # Associations
   belongs_to :appropriate_body
 
@@ -53,4 +55,11 @@ class PendingInductionSubmission < ApplicationRecord
   validates :confirmed,
             acceptance: { message: "Confirm if these details are correct or try your search again" },
             on: :check_ect
+
+  validates :outcome,
+            inclusion: {
+              in: PendingInductionSubmission.outcomes.keys,
+              message: "Outcome must be either 'passed' or 'failed'"
+            },
+            on: :record_outcome
 end

--- a/app/services/appropriate_bodies/record_outcome.rb
+++ b/app/services/appropriate_bodies/record_outcome.rb
@@ -1,0 +1,17 @@
+module AppropriateBodies
+  class RecordOutcome
+    def initialize(appropriate_body:, pending_induction_submission:)
+      @appropriate_body = appropriate_body
+      @pending_induction_submission = pending_induction_submission
+    end
+
+    def record_outcome!
+      # FIXME: implement a proper release process here,
+      #        it needs to close the open inductoin
+      #        period and send an update to TRS with the
+      #        outcome and finish date
+
+      true
+    end
+  end
+end

--- a/app/views/appropriate_bodies/teachers/record_outcome/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/record_outcome/new.html.erb
@@ -1,0 +1,28 @@
+<% page_data(title: "Record outcome for #{Teachers::Name.new(@teacher).full_name}", error: @pending_induction_submission.errors.any?) %>
+
+<%= form_with(model: @pending_induction_submission, url: ab_teacher_record_outcome_path(@teacher), method: 'post') do |form| %>
+  <%= form.govuk_error_summary %>
+
+  <%=
+    form.govuk_date_field :finished_on,
+      legend: {
+        text: "When did #{Teachers::Name.new(@teacher).full_name} finish their induction with you?"
+      }
+  %>
+
+  <%=
+    form.govuk_number_field :number_of_terms,
+      width: 4,
+      label: {
+        size: 'm',
+        text: "How many terms of induction did #{Teachers::Name.new(@teacher).full_name} spend with you?"
+      }
+  %>
+
+  <%=
+    form.govuk_collection_radio_buttons :outcome, induction_outcome_choices, :identifier, :name,
+      legend: { text: "What was the outcome of #{Teachers::Name.new(@teacher).full_name}'s induction?", size: 'm' }
+  %>
+
+  <%= form.govuk_submit %>
+<% end %>

--- a/app/views/appropriate_bodies/teachers/record_outcome/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/record_outcome/show.html.erb
@@ -1,0 +1,10 @@
+<% page_data(
+  title: "#{Teachers::Name.new(@teacher).full_name}'s induction outcome has been recorded",
+  header: false)
+%>
+
+<%=
+  govuk_panel(title_text: "Success", text: "#{Teachers::Name.new(@teacher).full_name} has finished their induction")
+%>
+
+<%= govuk_button_link_to("Return to the homepage", ab_path, secondary: true) %>

--- a/app/views/appropriate_bodies/teachers/release_ect/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/release_ect/new.html.erb
@@ -1,4 +1,4 @@
-<% page_data(title: "Release #{Teachers::Name.new(@teacher).full_name}", error: false) %>
+<% page_data(title: "Release #{Teachers::Name.new(@teacher).full_name}", error: @pending_induction_submission.errors.any?) %>
 
 <%= form_with(model: @pending_induction_submission, url: ab_teacher_release_ect_path(@teacher), method: 'post') do |form| %>
   <%= form.govuk_error_summary %>
@@ -17,7 +17,7 @@
         size: 'm',
         text: "How many terms of induction did #{Teachers::Name.new(@teacher).full_name} spend with you?"
       }
-    %>
+  %>
 
   <%= form.govuk_submit %>
 <% end %>

--- a/app/views/appropriate_bodies/teachers/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-button-group">
   <%= govuk_button_link_to("Release ECT", new_ab_teacher_release_ect_path(@teacher), secondary: true) %>
-  <%= govuk_button_link_to("Record induction outcome", "#", secondary: true) %>
+  <%= govuk_button_link_to("Record induction outcome", new_ab_teacher_record_outcome_path(@teacher), secondary: true) %>
 </div>
 
 <h2 class="govuk-heading-m">Early career teacher<h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
     collection do
       resources :teachers, only: %i[show], controller: 'appropriate_bodies/teachers', as: 'ab_teachers' do
         resource :release_ect, only: %i[new create show], path: 'release', controller: 'appropriate_bodies/teachers/release_ect'
-        resource :record_outcome, only: %i[new create show], path: 'record-outcome', controller: 'appropriate_bodies/teachers/release_ect'
+        resource :record_outcome, only: %i[new create show], path: 'record-outcome', controller: 'appropriate_bodies/teachers/record_outcome'
       end
     end
     namespace :claim_an_ect, path: 'claim-an-ect' do

--- a/db/migrate/20241003132805_add_outcome_field_to_pending_induction_submission.rb
+++ b/db/migrate/20241003132805_add_outcome_field_to_pending_induction_submission.rb
@@ -1,0 +1,7 @@
+class AddOutcomeFieldToPendingInductionSubmission < ActiveRecord::Migration[7.2]
+  def change
+    create_enum 'induction_outcomes', %w[fail pass]
+
+    add_column 'pending_induction_submissions', 'outcome', 'enum', enum_type: 'induction_outcomes', null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_27_151728) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_03_132805) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_27_151728) do
   create_enum "dfe_role_type", ["admin", "super_admin", "finance"]
   create_enum "funding_eligibility_status", ["eligible_for_fip", "eligible_for_cip", "ineligible"]
   create_enum "gias_school_statuses", ["open", "closed", "proposed_to_close", "proposed_to_open"]
+  create_enum "induction_outcomes", ["fail", "pass"]
   create_enum "induction_programme", ["cip", "fip", "diy"]
 
   create_table "academic_years", primary_key: "year", id: :serial, force: :cascade do |t|
@@ -225,6 +226,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_27_151728) do
     t.string "trs_qts_status_description"
     t.date "trs_initial_teacher_training_end_date"
     t.string "trs_initial_teacher_training_provider_name"
+    t.enum "outcome", enum_type: "induction_outcomes"
     t.index ["appropriate_body_id"], name: "index_pending_induction_submissions_on_appropriate_body_id"
   end
 


### PR DESCRIPTION
This largely follows the release ECT pattern except it also captures the outcome (pass or fail).

| Record outcome form | Confirmation | 
| -------------- | -------------- |
| ![Screenshot from 2024-10-03 15-16-59](https://github.com/user-attachments/assets/247e29b4-3a3f-4d14-be78-b4b4592ba272) | ![Screenshot from 2024-10-03 15-17-12](https://github.com/user-attachments/assets/0421a1ac-0f9b-4868-98d9-3f9c4f5c76a2) |

The proper text, question order, etc will be decided on later.