### PR TITLE
Add `cpd-` prefix to deployment name

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -57,6 +57,6 @@ runs:
       shell: bash
       run: |
         make ci review get-cluster-credentials
-        kubectl exec -n cpd-development deployment/ec2-review-${{ inputs.pull-request-number }}-web -- sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 RAILS_ENV=${{ inputs.environment }} /usr/local/bin/bundle exec rails db:seed:replant"
+        kubectl exec -n cpd-development deployment/cpd-ec2-review-${{ inputs.pull-request-number }}-web -- sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 RAILS_ENV=${{ inputs.environment }} /usr/local/bin/bundle exec rails db:seed:replant"
       env:
         PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   packages: write
+  pull-requests: write
 
 jobs:
   lint:


### PR DESCRIPTION
The full deployment name starts with `cpd-ec2` but here it's just `ec2` and is causing the deployment to fail even though the review app itself is up and running. The final step, posting a message to the comments, fails.
