### PR TITLE
Fix incorrect env var name for `PULL_REQUEST_NUMBER`

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         make ci review terraform-destroy
       env:
-        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
     - name: Post Pull Request Comment
       if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
This should prevent the following error in runs:

```
Makefile:26: *** Missing PULL_REQUEST_NUMBER.  Stop.
```
