### PR TITLE
Rename validation contexts so they're consistent

### DIFF
--- a/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
@@ -17,7 +17,7 @@ module AppropriateBodies
         release_ect = AppropriateBodies::ReleaseECT.new(appropriate_body: @appropriate_body, pending_induction_submission: @pending_induction_submission)
 
         PendingInductionSubmission.transaction do
-          if @pending_induction_submission.save(context: :record_period) && release_ect.release!
+          if @pending_induction_submission.save(context: :release_ect) && release_ect.release!
             redirect_to ab_teacher_release_ect_path(@teacher)
           else
             render :new

--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -37,12 +37,12 @@ class PendingInductionSubmission < ApplicationRecord
 
   validates :finished_on,
             presence: { message: "Enter a finish date" },
-            on: :record_period
+            on: %i[release_ect record_outcome]
 
   validates :number_of_terms,
             inclusion: { in: 0..16,
                          message: "Terms must be between 0 and 16" },
-            on: :record_period
+            on: %i[release_ect record_outcome]
 
   validates :date_of_birth,
             presence: { message: "Enter a date of birth" },

--- a/spec/models/pending_induction_submission_spec.rb
+++ b/spec/models/pending_induction_submission_spec.rb
@@ -48,8 +48,16 @@ describe PendingInductionSubmission do
       it { is_expected.to validate_inclusion_of(:induction_programme).in_array(%w[fip cip diy]).with_message("Choose an induction programme").on(:register_ect) }
     end
 
+    describe "started_on" do
+      it { is_expected.to validate_presence_of(:started_on).with_message("Enter a start date").on(:register_ect) }
+    end
+
+    describe "finished_on" do
+      it { is_expected.to validate_presence_of(:finished_on).with_message("Enter a finish date").on(%i[release_ect record_outcome]) }
+    end
+
     describe "number_of_terms" do
-      it { is_expected.to validate_inclusion_of(:number_of_terms).in_range(0..16).with_message("Terms must be between 0 and 16").on(:record_period) }
+      it { is_expected.to validate_inclusion_of(:number_of_terms).in_range(0..16).with_message("Terms must be between 0 and 16").on(%i[release_ect record_outcome]) }
     end
 
     describe "confirmed" do


### PR DESCRIPTION
It's easier to follow when the validation contexts match the names of the flows/steps they're triggered by. Instead of grouping the releaseing and completion of an ECT induction into 'record_period' they've been split to 'release_ect' and 'record_outcome'. This makes it more obvious when they're used.
