### PR TITLE
[147] - Create sub navigation view component

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,0 +1,120 @@
+// primary navigation
+//
+// borrowed from x-govuk/govuk-prototype-components
+// https://github.com/x-govuk/govuk-prototype-components/blob/main/x-govuk/components/primary-navigation/_primary-navigation.scss
+.x-govuk-primary-navigation {
+  @include govuk-font(19, $weight: bold);
+  background-color: govuk-colour("light-grey");
+  border-bottom: 1px solid transparent;
+  margin-bottom: -1px;
+  padding-inline: .5em;
+}
+
+.x-govuk-primary-navigation__list {
+  @include govuk-clearfix;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  width: calc(100% + #{govuk-spacing(6)});
+}
+
+.x-govuk-primary-navigation__item {
+  box-sizing: border-box;
+  display: block;
+  float: left;
+  height: 55px;
+  line-height: 55px;
+  margin-right: govuk-spacing(6);
+  position: relative;
+}
+
+.x-govuk-primary-navigation__item--current {
+  border-bottom: $govuk-border-width-narrow solid $govuk-brand-colour;
+}
+
+.x-govuk-primary-navigation__item--align-right {
+  @include govuk-media-query($from: tablet) {
+    float: right;
+  }
+}
+
+.x-govuk-primary-navigation__link {
+  @include govuk-link-common;
+  @include govuk-link-style-no-visited-state;
+  @include govuk-link-style-no-underline;
+  @include govuk-typography-weight-bold;
+
+  // Extend the touch area of the link to the list
+  &::after {
+    bottom: 0;
+    content: "";
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+}
+
+// sub navigation
+//
+// borrowed from x-govuk/govuk-prototype-components
+// https://github.com/x-govuk/govuk-prototype-components/blob/main/x-govuk/components/sub-navigation/_sub-navigation.scss
+.x-govuk-sub-navigation {
+  @include govuk-font(16);
+}
+
+.x-govuk-sub-navigation__section {
+  list-style-type: none;
+  margin: 0 0 govuk-spacing(4);
+  padding: 0;
+}
+
+.x-govuk-sub-navigation__link {
+  @include govuk-link-common;
+  @include govuk-link-style-no-visited-state;
+  @include govuk-link-style-no-underline;
+  padding-bottom: govuk-spacing(1);
+  padding-top: govuk-spacing(1);
+
+  &:not(:focus):hover {
+    color: $govuk-link-colour;
+  }
+}
+
+.x-govuk-sub-navigation__section-item {
+  margin-bottom: govuk-spacing(1);
+  padding-bottom: govuk-spacing(1);
+  padding-top: govuk-spacing(1);
+}
+
+.x-govuk-sub-navigation__section-item--current {
+  $_current-indicator-width: 4px;
+  background-color: govuk-colour("white");
+  border-left: $_current-indicator-width solid $govuk-brand-colour;
+  margin-left: -(govuk-spacing(2) + $_current-indicator-width);
+  padding-left: govuk-spacing(2);
+}
+
+.x-govuk-sub-navigation__link[aria-current] {
+  font-weight: bold;
+}
+
+.x-govuk-sub-navigation__section--nested {
+  margin-bottom: 0;
+  margin-top: govuk-spacing(2);
+  padding-left: govuk-spacing(4);
+}
+
+.x-govuk-sub-navigation__section--nested .x-govuk-sub-navigation__section-item::before {
+  color: govuk-colour("dark-grey");
+  content: "—";
+  margin-left: -(govuk-spacing(4));
+}
+
+.x-govuk-sub-navigation__theme {
+  @include govuk-font(19);
+  color: govuk-colour("dark-grey");
+  margin: 0;
+  padding: govuk-spacing(2) govuk-spacing(3) govuk-spacing(2) 0;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,3 +10,6 @@ $govuk-assets-path: "/";
 
 // library styles
 @import "accessible-autocomplete/src/autocomplete";
+
+// X-Govuk Prototype
+@import "admin";

--- a/app/components/navigation/structures/admin_sub_navigation.rb
+++ b/app/components/navigation/structures/admin_sub_navigation.rb
@@ -1,0 +1,51 @@
+module Navigation
+  module Structures
+    class AdminSubNavigation < Navigation::Structures::BaseSubNavigation
+      def get
+        [
+          Node.new(
+            name: "Admin",
+            href: "#",
+            prefix: "/admin",
+            nodes: [
+              Node.new(
+                name: "Admin 1.1",
+                href: '#',
+                prefix: "/admin/1.1"
+              ),
+              Node.new(
+                name: "Admin 1.2",
+                href: '#',
+                prefix: "/admin/1.2"
+              )
+            ]
+          ),
+          Node.new(
+            name: "Sub Nav 2",
+            href: '#',
+            prefix: "/sub-nav-2",
+            nodes: [
+              Node.new(
+                name: "Sub Nav 2.1",
+                href: '#',
+                prefix: "/sub-nav-2.1"
+              ),
+            ]
+          ),
+          Node.new(
+            name: "Sub Nav 3",
+            href: '#',
+            prefix: "/sub-nav-3",
+            nodes: [
+              Node.new(
+                name: "Sub Nav 3.1",
+                href: '#',
+                prefix: "/sub-nav-3.1"
+              ),
+            ]
+          ),
+        ]
+      end
+    end
+  end
+end

--- a/app/components/navigation/structures/base_sub_navigation.rb
+++ b/app/components/navigation/structures/base_sub_navigation.rb
@@ -1,0 +1,19 @@
+module Navigation
+  module Structures
+    class BaseSubNavigation
+      include Rails.application.routes.url_helpers
+
+      # A Node is an entry in a navigation list, it contains:
+      #
+      # * name    - the hyperlink text which appears in the list
+      # * href    - the hyperlink href
+      # * prefix  - the beginning of a path which will trigger the node to be marked
+      #            'current' and highlighted in the nav
+      # * current - a boolean value where the result of the prefix match is stored,
+      #             this isn't done on the fly so we can pass the value along from
+      #             the primary nav to the sub nav
+      # * nodes   - a list of nodes that sit under this one in the structure
+      Node = Struct.new(:name, :href, :prefix, :nodes)
+    end
+  end
+end

--- a/app/components/navigation/sub_navigation_component.html.erb
+++ b/app/components/navigation/sub_navigation_component.html.erb
@@ -1,0 +1,20 @@
+<nav class="x-govuk-sub-navigation" aria-labelledby="sub-navigation-heading">
+  <h2 class="govuk-visually-hidden" id="sub-navigation-heading">Navigation</h2>
+    <ul class="x-govuk-sub-navigation__section">
+      <% structure.each do |section| %>
+      <%= tag.li(class: navigation_item_classes(section)) do %>
+        <%= navigation_link(section) %>
+
+        <% if section.nodes.present? %>
+          <ul class="x-govuk-sub-navigation__section x-govuk-sub-navigation__section--nested">
+            <% section.nodes.each do |node| %>
+              <li class="x-govuk-sub-navigation__section-item">
+                <%= navigation_link(node) %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
+    <% end %>
+  </ul>
+</nav>

--- a/app/components/navigation/sub_navigation_component.rb
+++ b/app/components/navigation/sub_navigation_component.rb
@@ -1,0 +1,41 @@
+require 'debug'
+
+module Navigation
+  class SubNavigationComponent < ViewComponent::Base
+    attr_accessor :current_path, :current_section, :structure
+
+    def initialize(current_path, structure:)
+      super
+      @current_path = current_path
+      @structure = structure
+    end
+
+    def render?
+      structure.present?
+    end
+
+    def navigation_link(section)
+      link_to(
+        section.name,
+        section.href,
+        class: "x-govuk-sub-navigation__link",
+        aria: { current: current?(section.prefix) }
+      )
+    end
+
+    def navigation_item_classes(section)
+      class_names(
+        "x-govuk-sub-navigation__section-item",
+        "x-govuk-sub-navigation__section-item--current" => current?(section.prefix)
+      )
+    end
+
+  private
+
+    def current?(prefix)
+      # return nil instead of false so Rails' link helper drops the
+      # attribute rather than setting "current='false'"
+      current_path.start_with?(prefix) || nil
+    end
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,5 @@
+module AdminHelper
+  def admin_sub_navigation_structure
+    @admin_sub_navigation_structure ||= Navigation::Structures::AdminSubNavigation.new.get
+  end
+end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -12,3 +12,13 @@
     { key: { text: "Session expires" }, value: { text: session_manager.expires_at.localtime.to_fs(:govuk) } },
   ]
 ) %>
+
+<%= content_for(:sidebar) do %>
+  <%=
+    render Navigation::SubNavigationComponent.new(
+      request.path,
+      structure: admin_sub_navigation_structure
+    )
+  %>
+<% end %>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,16 +16,16 @@
 
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
-            <%= yield(:page_header) %>
-
-            <%= yield %>
-          </div>
           <% if content_for?(:sidebar) %>
             <div class="govuk-grid-column-one-third">
               <%= yield(:sidebar) %>
             </div>
           <% end %>
+          <div class="govuk-grid-column-two-thirds">
+            <%= yield(:page_header) %>
+
+            <%= yield %>
+          </div>
         </div>
       </main>
     </div>

--- a/spec/components/navigation/sub_navigation_component_spec.rb
+++ b/spec/components/navigation/sub_navigation_component_spec.rb
@@ -1,0 +1,146 @@
+require "rails_helper"
+
+class TestSubNavigationStructureTwoLevels < Navigation::Structures::BaseSubNavigation
+  def get
+    [
+      Node.new(
+        name: "This is the Sub Nav 1 page",
+        href: "/sub-nav-1",
+        prefix: "/sub-nav-1",
+        nodes: [
+          Node.new(
+            name: "This is the Sub Nav 1.1 page",
+            href: "/sub-nav-1.1",
+            prefix: "/sub-nav-1.1"
+          ),
+        ]
+      ),
+      Node.new(
+        name: "This is the Sub Nav 2 page",
+        href: "/sub-nav-2",
+        prefix: "/sub-nav-2",
+        nodes: [
+          Node.new(
+            name: "This is the Sub Nav 2.1 page",
+            href: '/sub-nav-2.1',
+            prefix: "/sub-nav-2.1"
+          ),
+        ]
+      ),
+    ]
+  end
+end
+
+class TestSubNavigationStructureOneLevel < Navigation::Structures::BaseSubNavigation
+  def get
+    [
+      Node.new(
+        name: "This is the Sub Nav 1 page",
+        href: '/sub-nav-1',
+        prefix: "/sub-nav-1"
+      )
+    ]
+  end
+end
+
+RSpec.describe Navigation::SubNavigationComponent, type: :component do
+  describe "a nested navigation structure with two levels" do
+    let(:current_path) { "/some-path" }
+    let(:structure) { TestSubNavigationStructureTwoLevels.new }
+
+    subject do
+      Navigation::SubNavigationComponent.new(current_path, structure: structure.get)
+    end
+
+    it "renders a visually hidden h2 heading" do
+      render_inline(subject)
+
+      expect(rendered_content).to have_css("h2.govuk-visually-hidden", text: "Navigation")
+    end
+
+    it "renders top level navigation items" do
+      render_inline(subject)
+
+      selector = "li.x-govuk-sub-navigation__section-item > a.x-govuk-sub-navigation__link"
+
+      expect(rendered_content).to have_css(selector, text: "This is the Sub Nav 1 page")
+      expect(rendered_content).to have_css(selector, text: "This is the Sub Nav 2 page")
+    end
+
+    it "renders second level navigation items" do
+      render_inline(subject)
+
+      selector = %w[
+        li.x-govuk-sub-navigation__section-item
+        ul.x-govuk-sub-navigation__section--nested
+        li.x-govuk-sub-navigation__section-item
+        a.x-govuk-sub-navigation__link
+      ].join(" > ")
+
+      expect(rendered_content).to have_css(selector, text: "This is the Sub Nav 1.1 page")
+      expect(rendered_content).to have_css(selector, text: "This is the Sub Nav 2.1 page")
+    end
+  end
+
+  describe "a navigation structure with only one level" do
+    let(:structure) { TestSubNavigationStructureOneLevel.new }
+    let(:current_path) { "/some-path" }
+
+    subject do
+      Navigation::SubNavigationComponent.new(current_path, structure: structure.get)
+    end
+
+    it "renders top level navigation items" do
+      render_inline(subject)
+
+      selector = "li.x-govuk-sub-navigation__section-item > a.x-govuk-sub-navigation__link"
+
+      expect(rendered_content).to have_css(selector, text: "This is the Sub Nav 1 page")
+    end
+  end
+
+  describe "highlighting the current top level nav item" do
+    context "when the prefix matches the start of the current path" do
+      let(:current_path) { "/sub-nav-1" }
+      let(:structure) { TestSubNavigationStructureTwoLevels.new }
+
+      subject do
+        Navigation::SubNavigationComponent.new(current_path, structure: structure.get)
+      end
+
+      it "marks only the nav item with the matching prefix as 'current'" do
+        render_inline(subject)
+
+        selector = "li.x-govuk-sub-navigation__section-item--current"
+
+        expect(rendered_content).to have_css(selector, text: "This is the Sub Nav 1 page")
+        expect(rendered_content).to have_css(selector, count: 1)
+      end
+    end
+  end
+
+  describe "highlighting the current second level nav item" do
+    context "when the prefix matches the start of the current path" do
+      let(:current_path) { "/sub-nav-1.1" }
+      let(:structure) { TestSubNavigationStructureTwoLevels.new }
+
+      subject do
+        Navigation::SubNavigationComponent.new(current_path, structure: structure.get)
+      end
+
+      it "marks only the section as current" do
+        render_inline(subject)
+
+        selector = %w[
+          li.x-govuk-sub-navigation__section-item
+          ul.x-govuk-sub-navigation__section--nested
+          li.x-govuk-sub-navigation__section-item
+          a.x-govuk-sub-navigation__link[aria-current="true"]
+        ].join(" > ")
+
+        expect(rendered_content).to have_css(selector, text: "This is the Sub Nav 1.1 page")
+        expect(rendered_content).to have_css(selector, count: 1)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,12 @@
+require "capybara/rspec"
+require "view_component/test_helpers"
+require "view_component/system_test_helpers"
+
 RSpec.configure do |config|
+  config.include ViewComponent::TestHelpers, type: :component
+  config.include ViewComponent::SystemTestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
### Ticket
https://github.com/orgs/DFE-Digital/projects/48/views/1?pane=issue&itemId=75955829&issue=DFE-Digital%7Cregister-early-career-teachers%7C147 

### Changes

Creates first iteration of sub navigation view component for the admin page 

### Notes

- Code largely inspired by @peteryates [similar work in the NPQ service](https://github.com/DFE-Digital/npq-registration/pull/1222). The key difference being that we are already using `govuk_service_navigation` view component for the primary navigation, so the sub navigation view component has been made to work independently of this.

### Screenshot

<img width="887" alt="sub_nav" src="https://github.com/user-attachments/assets/1f696c8a-e166-40f1-949e-f6baeafbbc8a">