### PR TITLE
Ensure date of birth is present when claiming ECT

### DIFF
--- a/app/services/appropriate_bodies/claim_an_ect/find_ect.rb
+++ b/app/services/appropriate_bodies/claim_an_ect/find_ect.rb
@@ -15,6 +15,8 @@ module AppropriateBodies
         #       b) as another pending induction submission?
         #       we probably want a guard clause here or to make the if statement
         #       below a case and add different errors to the :base
+        return unless pending_induction_submission.valid?(:find_ect)
+
         pending_induction_submission.assign_attributes(appropriate_body:, **find_matching_record_in_trs)
         pending_induction_submission.save(context: :find_ect)
       end

--- a/lib/TRS/api_client.rb
+++ b/lib/TRS/api_client.rb
@@ -9,7 +9,7 @@ module TRS
       end
     end
 
-    def find_teacher(trn:, date_of_birth: nil)
+    def find_teacher(trn:, date_of_birth:)
       response = @connection.get("/v3/persons/#{trn}", dateOfBirth: date_of_birth)
 
       if response.success?

--- a/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
+  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
+
   describe "#initialize" do
-    let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
     let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
 
     it "assigns the provided appropriate body and pending induction submission params" do
@@ -11,7 +12,17 @@ RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
     end
   end
 
-  describe "#import_from_trs" do
+  describe "#import_from_trs!" do
+    context "when the pending_induction_submission is invalid" do
+      let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, date_of_birth: nil) }
+
+      it "returns nil" do
+        find_ect = AppropriateBodies::ClaimAnECT::FindECT.new(appropriate_body:, pending_induction_submission:)
+
+        expect(find_ect.import_from_trs!).to be_nil
+      end
+    end
+
     context "when there is a match" do
       it "makes a call to the TRS API client with the expected parameters"
       it "assigns the incoming attributes to the pending_induction_submission and returns it"


### PR DESCRIPTION
We were able to get past this check because we were calling the API regardless of whether the pending_induction_submission was valid. This change ensures we return before calling if validation fails.

![image](https://github.com/user-attachments/assets/31d368d6-b71a-48c3-9dff-ae135e062cfb)
