### PR TITLE
Fix login screen when personas is disabled

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,11 @@
+module SessionsHelper
+  def login_options
+    options = [govuk_link_to("Sign-in with a one time password", otp_sign_in_path, no_visited_state: true)]
+
+    if Rails.application.config.enable_personas
+      options << govuk_link_to("Sign-in with a persona", personas_path, no_visited_state: true)
+    end
+
+    options
+  end
+end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,6 +1,3 @@
 <% page_data(title: "Select a sign in method") %>
 
-<%= govuk_list [
-  govuk_link_to("Sign-in with a one time password", otp_sign_in_path, no_visited_state: true),
-  govuk_link_to("Sign-in with a persona", personas_path, no_visited_state: true)
-] %>
+<%= govuk_list(login_options) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   get '/otp-sign-in/code', to: 'otp_sessions#request_code'
   post '/otp-sign-in/verify', to: 'otp_sessions#verify_code'
 
-  if Rails.application.config.enable_personas
+  constraints -> { Rails.application.config.enable_personas } do
     get 'personas', to: 'personas#index'
   end
 

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe SessionsHelper, type: :helper do
+  include GovukLinkHelper
+  include GovukVisuallyHiddenHelper
+
+  describe '#login_options' do
+    let(:one_time_password_link_text) { 'Sign-in with a one time password' }
+    let(:persona_link_text) { 'Sign-in with a persona' }
+
+    context 'when personas are enabled (ENABLE_PERSONAS=true)' do
+      before { allow(Rails.application.config).to receive(:enable_personas).and_return(true) }
+
+      it 'includes one time password' do
+        expect(login_options).to have_css('a', text: one_time_password_link_text)
+      end
+
+      it 'includes one time persona' do
+        expect(login_options).to have_css('a', text: persona_link_text)
+      end
+    end
+
+    context 'when personas are enabled (ENABLE_PERSONAS=false)' do
+      before { allow(Rails.application.config).to receive(:enable_personas).and_return(false) }
+
+      it 'includes one time password' do
+        expect(login_options).to have_css('a', text: one_time_password_link_text)
+      end
+
+      it 'does not include one time persona' do
+        expect(login_options).not_to have_css('a', text: persona_link_text)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The personas_path is now unreachable when `ENABLE_PERSONAS` is false, so we want to avoid calling the helper elsewhere. Moving the logic to a helper tidies the logic up and makes it easier to test.