### PR TITLE
chore: deploy the review app if files in 'app' folder are touched

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+Review:
+- changed-files:
+  - any-glob-to-any-file:
+    - app/**

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,17 +47,28 @@ jobs:
           docker-repository: ghcr.io/dfe-digital/ecf2
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  add-review-label:
+    name: Add review label to PR
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply labels based on file changes
+        uses: actions/labeler@v5
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   deploy-review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Deploy')
-    needs: [docker]
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Review')
+    needs: [add-review-label, docker]
     runs-on: ubuntu-latest
     environment:
       name: review
     steps:
       - uses: actions/checkout@v4
-
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
         with:


### PR DESCRIPTION
### Context

Currently the review app is on deployed if the author remembers to add the 'Deploy' label. Sometimes this is forgotten. This is bad.

### Changes

Update the pipeline config to deploy the review app if any of the files in the `app` folder change. Restricting it to this folder will mean we do not create any unnecessary review app deploys (for example when Dependabot updates dependencies)