### PR TITLE
Reinstate release ECT button from teacher view page

### DIFF
--- a/app/views/appropriate_bodies/teachers/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/show.html.erb
@@ -1,7 +1,8 @@
 <% page_data(title: Teachers::Name.new(@teacher).full_name, error: false) %>
 
 <div class="govuk-button-group">
-  <%= govuk_button_link_to("Record induction outcome", new_ab_teacher_record_outcome_path(@teacher)) %>
+  <%= govuk_button_link_to("Release ECT", new_ab_teacher_release_ect_path(@teacher), secondary: true) %>
+  <%= govuk_button_link_to("Record induction outcome", new_ab_teacher_record_outcome_path(@teacher), secondary: true) %>
 </div>
 
 <h2 class="govuk-heading-m">Early career teacher<h2>


### PR DESCRIPTION
Small change, just re-add the 'Release ECT' button to AB teacher overview. Also make them secondary, I'm not sure one should take precedence here - one is _final_ but I'd argue it's not the _main call to action_ on the page.

| Before | After |
| ----- | ------ |
|![image](https://github.com/user-attachments/assets/2e75029f-36b1-4dbc-b3d3-72d12513da0e)|  ![Screenshot from 2024-10-14 15-22-47](https://github.com/user-attachments/assets/a449468e-812f-43d6-82f9-0ff812433e4d) |