### PR TITLE
Fix terraform version on destroy

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version: 1.6.4
+        terraform_version: 1.9.5
         terraform_wrapper: false
 
     - uses: DFE-Digital/github-actions/set-kubelogin-environment@master

--- a/spec/misc/terraform_versions_spec.rb
+++ b/spec/misc/terraform_versions_spec.rb
@@ -1,0 +1,22 @@
+def extract_terraform_version(file, match_on)
+  return unless (matching_line = file.find { |f| f =~ match_on })
+
+  matching_line.scan(%r{\d+\.\d+\.\d+}).first
+end
+
+describe 'Terraform versions' do
+  versions_in_deployments = Dir.glob(Rails.root.join(".github/**/*.*"))
+                                .index_with { |file| extract_terraform_version(File.open(file), /terraform_version/) }
+                                .compact
+
+  version_in_config = File.open(Rails.root.join("config/terraform/application/terraform.tf"))
+                          .then { |version_line| extract_terraform_version(version_line, /required_version/) }
+
+  versions_in_deployments.each do |file, version|
+    context file do
+      it "is at version #{version_in_config}" do
+        expect(version).to eql(version_in_config)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This makes sure our `delete_review_app.yml` flow is at 1.9.5 and adds a spec that we don't have any version mismatch across our deployment files in `.github`.

Fixes #471 