### PR TITLE
Remove conditional logic from deploy workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,0 @@
-Review:
-- changed-files:
-  - any-glob-to-any-file:
-    - app/**

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -12,7 +12,6 @@ jobs:
     name: Delete Review App ${{ github.event.pull_request.number }}
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'Deploy') }}
     environment: review
     steps:
     - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,23 +47,10 @@ jobs:
           docker-repository: ghcr.io/dfe-digital/ecf2
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  add-review-label:
-    name: Add review label to PR
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Apply labels based on file changes
-        uses: actions/labeler@v5
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
   deploy-review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Review')
-    needs: [add-review-label, docker]
+    needs: docker
     runs-on: ubuntu-latest
     environment:
       name: review


### PR DESCRIPTION
Adding a label as part of the workflow doesn't work because GitHub appears to check whether the label's presence right at the beginning of the run, so regardless of which order things happen in, it's not soon enough.

For now, let's just create a review app every time.
