### PR TITLE
Fix broken broken page (schools/home/ects)

### DIFF
--- a/app/controllers/schools/home_controller.rb
+++ b/app/controllers/schools/home_controller.rb
@@ -12,10 +12,9 @@ module Schools
 
     def school
       # This is temporary. 'School' will be set once DfE signin hooked up
-      school_id = 1
       @school ||= School.joins(:gias_school)
                         .select("schools.id, gias_schools.name")
-                        .find(school_id)
+                        .first
     end
   end
 end


### PR DESCRIPTION
### Context
When a user visits '/schools/home/ect' we will set the school following sign-in via DfE Sign-in. Until then we are just setting the school universally so that we access the right seed data. Currently though the page breaks in the review app and higher environments (I'm guessing because a school with id = 1 cannot be found).

### Changes
- Do not hardcode the school id.
