### PR TITLE
[473] - Add 'Find ECT' page - part 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ FROM ruby:3.3.4-alpine as builder
 #     apk add --update --no-cache gcc git libc6-compat libc-dev make nodejs \
 #     postgresql13-dev
 
+RUN apk -U upgrade && \
+    apk add --update --no-cache git
+
 WORKDIR /app
 
 # Add the timezone (builder image) as it's not configured by default in Alpine

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rails", "~> 7.2.1"
 
 gem "bootsnap", require: false
 gem "cssbundling-rails"
+gem "dfe-wizard", github: "DFE-Digital/dfe-wizard"
 gem "jsbundling-rails"
 gem "pg", "~> 1.5"
 gem "propshaft"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/DFE-Digital/dfe-wizard.git
+  revision: 6b2f76e4e3f9f1ac14e67066e27fc50964618b3e
+  specs:
+    dfe-wizard (0.1.1)
+      activemodel
+      activesupport
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -561,6 +569,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dfe-wizard!
   factory_bot_rails
   faker
   govuk-components

--- a/app/controllers/schools/register_ect_controller.rb
+++ b/app/controllers/schools/register_ect_controller.rb
@@ -1,6 +1,58 @@
+# frozen_string_literal: true
+
 module Schools
   class RegisterECTController < ApplicationController
+    before_action :initialize_wizard
+
+    FORM_KEY = :register_ect_wizard
+    WIZARD_CLASS = Schools::RegisterECT::BaseWizard.freeze
+
     def start
+    end
+
+    def new
+      render current_step
+    end
+
+    def create
+      if @wizard.valid_step?
+        @wizard.save!
+
+        redirect_to @wizard.next_step_path
+      else
+        render current_step
+      end
+    end
+
+  private
+
+    def initialize_wizard
+      @wizard = WIZARD_CLASS.new(
+        current_step:,
+        step_params:,
+        store:
+      )
+    end
+
+    def store
+      @store ||= FormData::WizardStepStore.new(session:, form_key: FORM_KEY)
+    end
+
+    def current_step
+      step_from_path = request.path.split("/").last.underscore.to_sym
+      return :not_found if WIZARD_CLASS.steps.first.keys.exclude?(step_from_path)
+
+      step_from_path
+    end
+
+    def step_params
+      return default_params if params[current_step].blank?
+
+      params
+    end
+
+    def default_params
+      ActionController::Parameters.new({ current_step => params })
     end
   end
 end

--- a/app/services/form_data/data_store.rb
+++ b/app/services/form_data/data_store.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class FormData::DataStore
+  def initialize(session:, form_key:)
+    @session = session
+    @form_key = form_key
+  end
+
+  def store
+    session[form_key] ||= {}
+  end
+
+  def set(key, value)
+    store[key.to_sym] = value
+  end
+
+  def get(key)
+    store[key]
+  end
+
+  def clean
+    @session[@form_key] = {}
+  end
+
+  def destroy
+    @session.delete(@form_key)
+  end
+
+private
+
+  attr_reader :session, :form_key
+end

--- a/app/services/form_data/wizard_step_store.rb
+++ b/app/services/form_data/wizard_step_store.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FormData
+  class WizardStepStore < DataStore
+    def store_attrs(step, attrs)
+      set(step, attrs)
+    end
+
+    def attrs_for(step)
+      get(step) || {}
+    end
+  end
+end

--- a/app/validators/teacher_reference_number_validator.rb
+++ b/app/validators/teacher_reference_number_validator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class TeacherReferenceNumberValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    teacher_ref_number = Schools::Validation::TeacherReferenceNumber.new(value)
+    unless teacher_ref_number.valid?
+      message_scope = "errors.teacher_reference_number"
+      record.errors.add(attribute, I18n.t(teacher_ref_number.format_error, scope: message_scope))
+    end
+  end
+end

--- a/app/views/schools/register_ect/find_ect.html.erb
+++ b/app/views/schools/register_ect/find_ect.html.erb
@@ -1,0 +1,23 @@
+<% page_data(title: "Find an ECT", error: true, backlink_href: schools_register_ect_start_path ) %>
+
+<p class="govuk-body">Enter your ECT's teacher reference number and date of birth to find them.</p>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_number_field(
+        :trn,
+        label: { text: "Teacher reference number (TRN)", size: "m" },
+        hint: { text: "Enter your ECT's TRN (they are 7 digits long). It's on their pay slip, teaching contract or registration document from the General Teaching Council for England (GTCE).", size: "s" },
+      )
+  %>
+
+  <%= f.govuk_date_field :date_of_birth,
+                         date_of_birth: true,
+                         width: "two-thirds",
+                         legend: { text: 'Date of birth', size: "m", tag: "h3" },
+                         hint: { text: "For example, 31 3 1980"}
+  %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/schools/register_ect/review_ect_details.html.erb
+++ b/app/views/schools/register_ect/review_ect_details.html.erb
@@ -1,0 +1,1 @@
+<% page_data(title: "Check if this is your ECT", error: true, backlink_href: schools_register_ect_find_ect_path ) %>

--- a/app/views/schools/register_ect/start.html.erb
+++ b/app/views/schools/register_ect/start.html.erb
@@ -1,4 +1,4 @@
-<% page_data(title: "What you'll need", error: false) %>
+<% page_data(title: "What you'll need to register a new ECT", error: false) %>
 
 <h2 class="govuk-heading-m">Personal information</h2>
 <p class="govuk-body">You must provide your ECT's:</p>
@@ -18,7 +18,7 @@
   <li>mentor</li>
 </ul>
 
-<p class="govuk-body">If you have not assigned a mentor for your ECT, you can still register them and provide the
+<p class="govuk-body">If you have not assigned a mentor for your ECT, you can still register them by providing the
   mentor's details later.</p>
 
 <button class="govuk-button">Continue</button>

--- a/app/views/schools/register_ect/start.html.erb
+++ b/app/views/schools/register_ect/start.html.erb
@@ -21,4 +21,5 @@
 <p class="govuk-body">If you have not assigned a mentor for your ECT, you can still register them by providing the
   mentor's details later.</p>
 
-<button class="govuk-button">Continue</button>
+<%= govuk_button_link_to("Continue", schools_register_ect_find_ect_path) %>
+

--- a/app/wizards/schools/register_ect/base_wizard.rb
+++ b/app/wizards/schools/register_ect/base_wizard.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Schools
+  module RegisterECT
+    class BaseWizard < DfE::Wizard::Base
+      attr_accessor :store, :trn, :date_of_birth
+
+      steps do
+        [
+          {
+            find_ect: FindECTStep,
+            review_ect_details: ReviewECTDetailsStep
+          }
+        ]
+      end
+
+      delegate :save!, to: :current_step
+    end
+  end
+end

--- a/app/wizards/schools/register_ect/find_ect_step.rb
+++ b/app/wizards/schools/register_ect/find_ect_step.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Schools
+  module RegisterECT
+    class FindECTStep < StoredStep
+      include ActiveRecord::AttributeAssignment
+
+      attr_accessor :trn, :date_of_birth
+
+      # validate :trn_validation
+
+      validates :trn, presence: true, teacher_reference_number: true
+
+      validates :date_of_birth,
+                presence: {
+                  message: "Please enter date of birth"
+                }
+
+      def self.permitted_params
+        %i[trn date_of_birth]
+      end
+
+      def next_step
+        :review_ect_details
+      end
+
+      # private
+
+      # def trn_validation
+      #   teacher_ref_number = TeacherReferenceNumber.new(trn)
+      #
+      #   unless teacher_ref_number.valid?
+      #     message_scope = "errors.teacher_reference_number"
+      #     errors.add(:trn, I18n.t(teacher_ref_number.format_error, scope: message_scope))
+      #   end
+      # end
+    end
+  end
+end

--- a/app/wizards/schools/register_ect/review_ect_details_step.rb
+++ b/app/wizards/schools/register_ect/review_ect_details_step.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Schools
+  module RegisterECT
+    class ReviewECTDetailsStep < StoredStep
+      def self.permitted_params
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_ect/stored_step.rb
+++ b/app/wizards/schools/register_ect/stored_step.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Schools
+  module RegisterECT
+    class StoredStep < DfE::Wizard::Step
+      def save!
+        store.store_attrs(key, wizard.step_params.to_h)
+      end
+
+      def stored_attrs
+        store.attrs_for(key)
+      end
+
+      def key
+        model_name.param_key
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,1 +1,7 @@
 en:
+  errors:
+    teacher_reference_number:
+      blank: Enter the teacher reference number (TRN)
+      too_short: Teacher reference number must include at least 5 digits
+      too_long: Teacher reference number cannot include more than 7 digits
+      invalid: Teacher reference number must include at least 5 digits

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,5 +65,11 @@ Rails.application.routes.draw do
   namespace :schools do
     get "/home/ects", to: "home#index", as: :ects_home
     get "/what-you-will-need", to: "register_ect#start", as: :register_ect_start
+
+    get "/find-ect", to: "register_ect#new", as: :register_ect_find_ect
+    post "/find-ect", to: "register_ect#create"
+
+    get "/review-ect-details", to: "register_ect#new", as: :register_ect_review_ect_details
+    post "/review_ect_details", to: "register_ect#create"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,6 @@ Rails.application.routes.draw do
 
   namespace :schools do
     get "/home/ects", to: "home#index", as: :ects_home
-    get "/register-ect/start", to: "register_ect#start", as: :register_ect_start
+    get "/what-you-will-need", to: "register_ect#start", as: :register_ect_start
   end
 end

--- a/lib/schools/validation/teacher_reference_number.rb
+++ b/lib/schools/validation/teacher_reference_number.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Schools
+  module Validation
+    class TeacherReferenceNumber
+      MIN_UNPADDED_TRN_LENGTH = 5
+      PADDED_TRN_LENGTH = 7
+
+      attr_reader :trn, :format_error
+
+      def initialize(trn)
+        @trn = trn
+        @format_error = nil
+      end
+
+      def formatted_trn
+        @formatted_trn ||= extract_trn_value
+      end
+
+      def valid?
+        formatted_trn.present?
+      end
+
+    private
+
+      def extract_trn_value
+        @format_error = :blank and return if trn.blank?
+
+        # remove any characters that are not digits
+        only_digits = trn.to_s.gsub(/[^\d]/, "")
+
+        @format_error = :invalid and return if only_digits.blank?
+        @format_error = :too_short and return if only_digits.length < MIN_UNPADDED_TRN_LENGTH
+        @format_error = :too_long and return if only_digits.length > PADDED_TRN_LENGTH
+
+        only_digits.rjust(PADDED_TRN_LENGTH, "0")
+      end
+    end
+  end
+end

--- a/spec/features/schools/register_an_ect_spec.rb
+++ b/spec/features/schools/register_an_ect_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe 'Registering an ECT' do
+  let(:page) { RSpec.configuration.playwright_page }
+
+  before { sign_in_as_admin }
+
+  scenario 'Happy path' do
+    given_i_am_on_the_start_page
+    when_i_click_on_the_continue_link
+    i_should_be_taken_to_the_find_ect_page
+
+    when_i_fill_in_the_find_ect_form
+    and_i_click_on_the_continue_button
+    then_i_should_be_taken_to_the_review_ect_details_page
+  end
+
+  def given_i_am_on_the_start_page
+    path = '/schools/what-you-will-need'
+    page.goto path
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_click_on_the_continue_link
+    page.click('text=Continue')
+  end
+
+  def i_should_be_taken_to_the_find_ect_page
+    path = '/schools/find-ect'
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_fill_in_the_find_ect_form
+    page.fill('#find-ect-trn-field', '1234567')
+
+    page.fill('#find_ect_date_of_birth_3i', '10')
+    page.fill('#find_ect_date_of_birth_2i', '12')
+    page.fill('#find_ect_date_of_birth_1i', '1990')
+  end
+
+  def and_i_click_on_the_continue_button
+    page.click('text=Continue')
+  end
+
+  def then_i_should_be_taken_to_the_review_ect_details_page
+    path = '/schools/review-ect-details'
+    expect(page.url).to end_with(path)
+  end
+end


### PR DESCRIPTION
### Goal

As part of the Register ECT flow, users will need to retrieve and confirm the details of the teacher (ECT) they wish to register. 

There will be two PRs to achieve this: this one and an further one to call the TRS API to fetch the teacher details.


### Changes

1. This PR sets up the DfE Wizard gem and creates the page for the user to enter the TRN and date of birth for the teacher. Upon submit these details are stored in the session. 

**Note**:  Need to speak to another developer about handling 'date of birth'

2. Add 'happy path' feature spec to test the entire Register ECT journey to date

3. Copy and route update for the start page (What you will need)



<img width="1279" alt="Find ECT" src="https://github.com/user-attachments/assets/d730af14-a6c8-4d91-ac4f-434c5801b820">


