### PR TITLE
Add landing page for appropriate bodies

### DIFF
--- a/app/controllers/appropriate_bodies/landing_controller.rb
+++ b/app/controllers/appropriate_bodies/landing_controller.rb
@@ -1,0 +1,8 @@
+module AppropriateBodies
+  class LandingController < ApplicationController
+    skip_before_action :authenticate, only: :show
+
+    def show
+    end
+  end
+end

--- a/app/controllers/appropriate_bodies/teachers/record_outcome_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_outcome_controller.rb
@@ -2,13 +2,13 @@ module AppropriateBodies
   module Teachers
     class RecordOutcomeController < AppropriateBodiesController
       def new
-        @teacher = Teacher.find(params[:ab_teacher_id])
+        @teacher = Teacher.find(params[:teacher_id])
 
         @pending_induction_submission = PendingInductionSubmission.new
       end
 
       def create
-        @teacher = Teacher.find(params[:ab_teacher_id])
+        @teacher = Teacher.find(params[:teacher_id])
         @pending_induction_submission = PendingInductionSubmission.new(
           **pending_induction_submission_params,
           **pending_induction_submission_attributes
@@ -26,7 +26,7 @@ module AppropriateBodies
       end
 
       def show
-        @teacher = Teacher.find(params[:ab_teacher_id])
+        @teacher = Teacher.find(params[:teacher_id])
       end
 
     private

--- a/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
@@ -2,13 +2,13 @@ module AppropriateBodies
   module Teachers
     class ReleaseECTController < AppropriateBodiesController
       def new
-        @teacher = Teacher.find(params[:ab_teacher_id])
+        @teacher = Teacher.find(params[:teacher_id])
 
         @pending_induction_submission = PendingInductionSubmission.new
       end
 
       def create
-        @teacher = Teacher.find(params[:ab_teacher_id])
+        @teacher = Teacher.find(params[:teacher_id])
         @pending_induction_submission = PendingInductionSubmission.new(
           **pending_induction_submission_params,
           **pending_induction_submission_attributes
@@ -26,7 +26,7 @@ module AppropriateBodies
       end
 
       def show
-        @teacher = Teacher.find(params[:ab_teacher_id])
+        @teacher = Teacher.find(params[:teacher_id])
       end
 
     private

--- a/app/controllers/appropriate_bodies/teachers_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers_controller.rb
@@ -1,5 +1,13 @@
 module AppropriateBodies
   class TeachersController < AppropriateBodiesController
+    layout "full", only: :index
+
+    def index
+      # FIXME: find within the scope of the current AB
+
+      @teachers = ::Teachers::Search.new(params[:q]).search
+    end
+
     def show
       # FIXME: find within the scope of the current AB
 

--- a/app/controllers/appropriate_bodies_controller.rb
+++ b/app/controllers/appropriate_bodies_controller.rb
@@ -2,13 +2,6 @@ class AppropriateBodiesController < ApplicationController
   include Authorisation
 
   before_action :set_appropriate_body
-  layout "full", only: :show
-
-  def show
-    # FIXME: find within the scope of the current AB
-
-    @teachers = Teachers::Search.new(params[:q]).search
-  end
 
 private
 

--- a/app/views/appropriate_bodies/landing/show.html.erb
+++ b/app/views/appropriate_bodies/landing/show.html.erb
@@ -1,0 +1,24 @@
+<% page_data(title: "Record induction as an appropriate body", error: false) %>
+
+<p class="govuk-body">
+  This service is for appropriate bodies that are supporting the statutory induction of early career teachers (ECTs).
+</p>
+
+<p class="govuk-body">
+  Use this service to:
+</p>
+
+<%=
+  govuk_list(
+    [
+      %(report statutory induction details),
+      %(specify which ECTs' induction you support),
+      %(tell us which ECTs' induction you no longer support),
+      %(review an ECT's induction history and progress),
+      %(tell us if an ECT has passed, failed or had their induction extended)
+    ],
+    type: :bullet
+  )
+%>
+
+<%= govuk_start_button(text: 'Sign in', href: '#') %>

--- a/app/views/appropriate_bodies/teachers/index.html.erb
+++ b/app/views/appropriate_bodies/teachers/index.html.erb
@@ -1,0 +1,36 @@
+<% page_data(title: @appropriate_body.name, error: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= govuk_button_link_to("Claim an ECT", new_ab_claim_an_ect_find_path, secondary: true) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">Your ECTs</></h2>
+    <div class="search-box">
+      <%= form_with method: :get, class: "search-box__form" do |f| %>
+        <div class="search-box__input">
+          <%= f.govuk_text_field(
+                "q",
+                value: params[:q],
+                label: { text: "Search for an ECT", size: "s" },
+                hint: { text: "placeholder" },
+              )
+          %>
+        </div>
+
+        <%= f.govuk_submit "Search" %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <ul class="govuk-list govuk-list--bullet">
+      <% @teachers.all.each do |teacher| %>
+        <%= summary_card_for_teacher(teacher) %>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resource :appropriate_bodies, only: %i[show], path: 'appropriate-body', as: 'ab'
+  resource :appropriate_bodies, only: %i[show], path: 'appropriate-body', as: 'ab_landing', controller: 'appropriate_bodies/landing'
   namespace :appropriate_bodies, path: 'appropriate-body', as: 'ab' do
     resources :teachers, only: %i[index show], controller: 'teachers', as: 'teachers' do
       resource :release_ect, only: %i[new create show], path: 'release', controller: 'teachers/release_ect'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
 
   resource :appropriate_bodies, only: %i[show], path: 'appropriate-body', as: 'ab'
   namespace :appropriate_bodies, path: 'appropriate-body', as: 'ab' do
-    resources :teachers, only: %i[show], controller: 'teachers', as: 'teachers' do
+    resources :teachers, only: %i[index show], controller: 'teachers', as: 'teachers' do
       resource :release_ect, only: %i[new create show], path: 'release', controller: 'teachers/release_ect'
       resource :record_outcome, only: %i[new create show], path: 'record-outcome', controller: 'teachers/record_outcome'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,13 +44,13 @@ Rails.application.routes.draw do
     end
   end
 
-  resource :appropriate_bodies, only: %i[show], path: 'appropriate-body', as: 'ab' do
-    collection do
-      resources :teachers, only: %i[show], controller: 'appropriate_bodies/teachers', as: 'ab_teachers' do
-        resource :release_ect, only: %i[new create show], path: 'release', controller: 'appropriate_bodies/teachers/release_ect'
-        resource :record_outcome, only: %i[new create show], path: 'record-outcome', controller: 'appropriate_bodies/teachers/record_outcome'
-      end
+  resource :appropriate_bodies, only: %i[show], path: 'appropriate-body', as: 'ab'
+  namespace :appropriate_bodies, path: 'appropriate-body', as: 'ab' do
+    resources :teachers, only: %i[show], controller: 'teachers', as: 'teachers' do
+      resource :release_ect, only: %i[new create show], path: 'release', controller: 'teachers/release_ect'
+      resource :record_outcome, only: %i[new create show], path: 'record-outcome', controller: 'teachers/record_outcome'
     end
+
     namespace :claim_an_ect, path: 'claim-an-ect' do
       resource :find_ect, only: %i[new create], path: 'find-ect', controller: '/appropriate_bodies/claim_an_ect/find_ect', as: 'find' do
         namespace 'error', path: 'errors' do

--- a/spec/requests/appropriate_bodies/show_spec.rb
+++ b/spec/requests/appropriate_bodies/show_spec.rb
@@ -5,36 +5,10 @@ RSpec.describe "Appropriate Body landing page", type: :request do
   let(:appropriate_body) { user.appropriate_bodies.first }
 
   describe 'GET /appropriate-body' do
-    context 'when not signed in' do
-      it 'redirects to the signin page' do
-        get("/appropriate-body")
+    it 'renders despite not being logged in' do
+      get("/appropriate-body")
 
-        expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
-      end
-    end
-
-    context 'when signed in as an appropriate body user' do
-      let!(:user) { sign_in_as(:appropriate_body_user) }
-      let!(:emma) { FactoryBot.create(:teacher, first_name: 'Emma') }
-      let!(:john) { FactoryBot.create(:teacher, first_name: 'John') }
-
-      it 'finds the right PendingInductionSubmission record and renders the page' do
-        get("/appropriate-body")
-
-        expect(response).to be_successful
-        expect(response.body).to include(emma.first_name, john.first_name)
-      end
-
-      context "with a query parameter" do
-        it "filters the list of teachers" do
-          get("/appropriate-body?q=emma")
-          expect(response).to be_successful
-
-          expect(response.body).to include(emma.first_name)
-          expect(response.body).not_to include(john.first_name)
-        end
-      end
+      expect(response).to be_successful
     end
   end
 end

--- a/spec/requests/appropriate_bodies/teachers/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/index_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe "Appropriate Body landing page", type: :request do
+  include AuthHelper
+  let(:appropriate_body) { user.appropriate_bodies.first }
+
+  describe 'GET /appropriate-body/teachers' do
+    context 'when not signed in' do
+      it 'redirects to the signin page' do
+        get("/appropriate-body/teachers")
+
+        expect(response).to be_redirection
+        expect(response.redirect_url).to end_with('/sign-in')
+      end
+    end
+
+    context 'when signed in as an appropriate body user' do
+      let!(:user) { sign_in_as(:appropriate_body_user) }
+      let!(:emma) { FactoryBot.create(:teacher, first_name: 'Emma') }
+      let!(:john) { FactoryBot.create(:teacher, first_name: 'John') }
+
+      it 'finds the right PendingInductionSubmission record and renders the page' do
+        get("/appropriate-body/teachers")
+
+        expect(response).to be_successful
+        expect(response.body).to include(emma.first_name, john.first_name)
+      end
+
+      context "with a query parameter" do
+        it "filters the list of teachers" do
+          get("/appropriate-body/teachers?q=emma")
+          expect(response).to be_successful
+
+          expect(response.body).to include(emma.first_name)
+          expect(response.body).not_to include(john.first_name)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change introduces a landing page for appropriate bodies which can be found at `/appropriate-body`. To make way I had to move the current 'home' page to `teachers#index` (which makes sense for now as it's a list of teachers).

The copy on the landing page isn't final and should be reviewed here. I copied it from a Figma screenshot but it doesn't feel right in parts.

| Landing page |
| ------------- |
| ![image](https://github.com/user-attachments/assets/5ad0cf99-37e3-4471-ab44-f5462d3d3014) |


## Tasks

* [ ] add final heading
* [ ] make any content amendments
* [ ] add a href to the button