### PR TITLE
Move error summaries to the top of the page

### DIFF
--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 
 <%= form_for @roles_form, url: role_type_admin_user_path(@user), method: :get do |f| %>
-  <%= f.govuk_error_summary %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <%= f.govuk_collection_radio_buttons :role_type, Admin::RolesForm::ROLE_TYPES, :to_s, :humanize, legend: { text: "Choose role type" } %>
 

--- a/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
@@ -5,7 +5,7 @@
 %>
 
 <%= form_with(model: @pending_induction_submission, url: ab_claim_an_ect_check_path(@pending_induction_submission, method: 'patch')) do |f| %>
-  <%= f.govuk_error_summary %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <%=
     govuk_summary_list do |sl|

--- a/app/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <%= form_with(model: @pending_induction_submission, url: ab_claim_an_ect_find_path) do |f| %>
-  <%= f.govuk_error_summary %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <%=
     f.govuk_text_field(

--- a/app/views/appropriate_bodies/claim_an_ect/register_ect/edit.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/register_ect/edit.html.erb
@@ -4,7 +4,7 @@
 %>
 
 <%= form_with(model: @pending_induction_submission, url: ab_claim_an_ect_register_path(@pending_induction_submission, method: 'patch')) do |f| %>
-  <%= f.govuk_error_summary %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <%=
     f.govuk_date_field :started_on,

--- a/app/views/appropriate_bodies/teachers/record_outcome/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/record_outcome/new.html.erb
@@ -1,17 +1,17 @@
 <% page_data(title: "Record outcome for #{Teachers::Name.new(@teacher).full_name}", error: @pending_induction_submission.errors.any?) %>
 
-<%= form_with(model: @pending_induction_submission, url: ab_teacher_record_outcome_path(@teacher), method: 'post') do |form| %>
-  <%= content_for(:error_summary) { form.govuk_error_summary } %>
+<%= form_with(model: @pending_induction_submission, url: ab_teacher_record_outcome_path(@teacher), method: 'post') do |f| %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <%=
-    form.govuk_date_field :finished_on,
+    f.govuk_date_field :finished_on,
       legend: {
         text: "When did #{Teachers::Name.new(@teacher).full_name} finish their induction with you?"
       }
   %>
 
   <%=
-    form.govuk_number_field :number_of_terms,
+    f.govuk_number_field :number_of_terms,
       width: 4,
       label: {
         size: 'm',
@@ -20,9 +20,9 @@
   %>
 
   <%=
-    form.govuk_collection_radio_buttons :outcome, induction_outcome_choices, :identifier, :name,
+    f.govuk_collection_radio_buttons :outcome, induction_outcome_choices, :identifier, :name,
       legend: { text: "What was the outcome of #{Teachers::Name.new(@teacher).full_name}'s induction?", size: 'm' }
   %>
 
-  <%= form.govuk_submit %>
+  <%= f.govuk_submit %>
 <% end %>

--- a/app/views/appropriate_bodies/teachers/record_outcome/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/record_outcome/new.html.erb
@@ -1,7 +1,7 @@
 <% page_data(title: "Record outcome for #{Teachers::Name.new(@teacher).full_name}", error: @pending_induction_submission.errors.any?) %>
 
 <%= form_with(model: @pending_induction_submission, url: ab_teacher_record_outcome_path(@teacher), method: 'post') do |form| %>
-  <%= form.govuk_error_summary %>
+  <%= content_for(:error_summary) { form.govuk_error_summary } %>
 
   <%=
     form.govuk_date_field :finished_on,

--- a/app/views/appropriate_bodies/teachers/release_ect/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/release_ect/new.html.erb
@@ -1,17 +1,17 @@
 <% page_data(title: "Release #{Teachers::Name.new(@teacher).full_name}", error: @pending_induction_submission.errors.any?) %>
 
-<%= form_with(model: @pending_induction_submission, url: ab_teacher_release_ect_path(@teacher), method: 'post') do |form| %>
-  <%= content_for(:error_summary) { form.govuk_error_summary } %>
+<%= form_with(model: @pending_induction_submission, url: ab_teacher_release_ect_path(@teacher), method: 'post') do |f| %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <%=
-    form.govuk_date_field :finished_on,
+    f.govuk_date_field :finished_on,
       legend: {
         text: "When did #{Teachers::Name.new(@teacher).full_name} finish their induction with you?"
       }
   %>
 
   <%=
-    form.govuk_number_field :number_of_terms,
+    f.govuk_number_field :number_of_terms,
       width: 4,
       label: {
         size: 'm',
@@ -19,5 +19,5 @@
       }
   %>
 
-  <%= form.govuk_submit %>
+  <%= f.govuk_submit %>
 <% end %>

--- a/app/views/appropriate_bodies/teachers/release_ect/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/release_ect/new.html.erb
@@ -1,7 +1,7 @@
 <% page_data(title: "Release #{Teachers::Name.new(@teacher).full_name}", error: @pending_induction_submission.errors.any?) %>
 
 <%= form_with(model: @pending_induction_submission, url: ab_teacher_release_ect_path(@teacher), method: 'post') do |form| %>
-  <%= form.govuk_error_summary %>
+  <%= content_for(:error_summary) { form.govuk_error_summary } %>
 
   <%=
     form.govuk_date_field :finished_on,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,8 @@
       <% end %>
 
       <main class="govuk-main-wrapper" id="main-content" role="main">
+        <%= yield(:error_summary) %>
+
         <div class="govuk-grid-row">
           <% if content_for?(:sidebar) %>
             <div class="govuk-grid-column-one-third">

--- a/app/views/otp_sessions/new.html.erb
+++ b/app/views/otp_sessions/new.html.erb
@@ -1,7 +1,7 @@
 <% page_data(title: "Sign in", error: @otp_form.errors.any?) %>
 
 <%= form_for @otp_form, url: otp_sign_in_path, method: :post do |f| %>
-  <%= f.govuk_error_summary %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <p class="govuk-body">
     You need to request an email with a code to sign in.

--- a/app/views/otp_sessions/request_code.html.erb
+++ b/app/views/otp_sessions/request_code.html.erb
@@ -1,7 +1,7 @@
 <% page_data(title: "Enter your code", error: @otp_form.errors.any?) %>
 
 <%= form_for @otp_form, url: otp_sign_in_verify_path do |f| %>
-  <%= f.govuk_error_summary %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <p class="govuk-body">
     We’ve sent you an email with a sign in code.

--- a/app/views/schools/register_ect/find_ect.html.erb
+++ b/app/views/schools/register_ect/find_ect.html.erb
@@ -3,7 +3,7 @@
 <p class="govuk-body">Enter your ECT's teacher reference number and date of birth to find them.</p>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
-  <%= f.govuk_error_summary %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <%= f.govuk_number_field(
         :trn,


### PR DESCRIPTION
The desgin system suggests that error summaries are placed at the top of the page, beneath the back/breadcrumbs but before any other content.

> Put the error summary at the top of the main container. If your page includes breadcrumbs or a back link, place it below these, but above the \<h1\>.

This change introduces the error_summary content area which we can pass error summaries to so they're rendered in the right place.


| Before | After |
| ----- | ----- |
| ![Screenshot from 2024-10-29 10-03-33](https://github.com/user-attachments/assets/60c19486-1026-49d9-a4c3-93a3f18eca12) | ![image](https://github.com/user-attachments/assets/31a4ecd7-975a-4bc5-84ca-bca2bb463943) |