### PR TITLE
Set permissions for brakeman workflow

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -8,6 +8,13 @@ env:
 on:
   workflow_call:
 
+permissions:
+  # required for all workflows
+  security-events: write
+  # only required for workflows in private repositories
+  actions: read
+  contents: read
+
 jobs:
   brakeman-scan:
     name: Brakeman Scan


### PR DESCRIPTION
This was missing and causing a failure when we're trying to upload the SARIF file to GitHub. [The docs suggest using these permissions](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github).


