### PR TITLE
Make teacher search work with unaccented strings

### DIFF
--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -22,5 +22,5 @@ class Teacher < ApplicationRecord
             format: { with: TRN_FORMAT, message: "TRN must be 7 numeric digits" },
             uniqueness: { message: 'TRN already exists', case_sensitive: false }
 
-  scope :search, ->(query_string) { where('teachers.search @@ websearch_to_tsquery(?)', query_string) }
+  scope :search, ->(query_string) { where("teachers.search @@ websearch_to_tsquery('unaccented', ?)", query_string) }
 end

--- a/db/migrate/20240918160307_add_trs_teacher_fields_to_pending_induction_submissions.rb
+++ b/db/migrate/20240918160307_add_trs_teacher_fields_to_pending_induction_submissions.rb
@@ -1,4 +1,4 @@
-class AddTrsTeacherFieldsToPendingInductionSubmissions < ActiveRecord::Migration[7.2]
+class AddTRSTeacherFieldsToPendingInductionSubmissions < ActiveRecord::Migration[7.2]
   def change
     change_table :pending_induction_submissions, bulk: true do |t|
       t.string :trs_email_address

--- a/db/migrate/20241028105436_unaccent_teachers_search.rb
+++ b/db/migrate/20241028105436_unaccent_teachers_search.rb
@@ -1,0 +1,34 @@
+class UnaccentTeachersSearch < ActiveRecord::Migration[7.2]
+  def down
+    remove_column :teachers, :search, :tsvector, type: :tsvector, as: "to_tsvector('unaccented', #{tsvector_columns})", stored: true
+
+    execute <<~SQL
+      drop text search configuration unaccented;
+    SQL
+
+    disable_extension 'unaccent'
+
+    add_column :teachers, :search, :tsvector, type: :tsvector, as: "to_tsvector('english', #{tsvector_columns})", stored: true
+  end
+
+  def up
+    remove_column :teachers, :search, :tsvector, type: :tsvector, as: "to_tsvector('english', #{tsvector_columns})", stored: true
+
+    enable_extension 'unaccent'
+
+    execute <<~SQL
+      create text search configuration unaccented ( copy = simple );
+      alter text search configuration unaccented
+        alter mapping for hword, hword_part, word
+        with unaccent, simple;
+    SQL
+
+    add_column :teachers, :search, :tsvector, type: :tsvector, as: "to_tsvector('unaccented', #{tsvector_columns})", stored: true
+
+    add_index :teachers, :search, using: :gin
+  end
+
+  def tsvector_columns
+    %w[first_name last_name corrected_name].map { |col| "coalesce(#{col}, '')" }.join(" || ' ' || ")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_17_072716) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_28_105436) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
+  enable_extension "unaccent"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
@@ -378,7 +379,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_17_072716) do
     t.datetime "induction_start_date_submitted_to_trs_at"
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.virtual "search", type: :tsvector, as: "to_tsvector('english'::regconfig, (((((COALESCE(first_name, ''::character varying))::text || ' '::text) || (COALESCE(last_name, ''::character varying))::text) || ' '::text) || (COALESCE(corrected_name, ''::character varying))::text))", stored: true
+    t.virtual "search", type: :tsvector, as: "to_tsvector('unaccented'::regconfig, (((((COALESCE(first_name, ''::character varying))::text || ' '::text) || (COALESCE(last_name, ''::character varying))::text) || ' '::text) || (COALESCE(corrected_name, ''::character varying))::text))", stored: true
     t.index ["corrected_name"], name: "index_teachers_on_corrected_name"
     t.index ["first_name", "last_name", "corrected_name"], name: "index_teachers_on_first_name_and_last_name_and_corrected_name", opclass: :gin_trgm_ops, using: :gin
     t.index ["search"], name: "index_teachers_on_search", using: :gin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -125,6 +125,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_17_072716) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "administrative_district_name"
+    t.integer "local_authority_code", null: false
     t.string "local_authority_name"
     t.integer "establishment_number", null: false
     t.string "phase_name"
@@ -132,7 +133,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_17_072716) do
     t.string "type_name", null: false
     t.integer "ukprn"
     t.string "website"
-    t.integer "local_authority_code", null: false
     t.boolean "induction_eligibility", null: false
     t.boolean "in_england", null: false
     t.index ["name"], name: "index_gias_schools_on_name"
@@ -375,10 +375,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_17_072716) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "trn", null: false
+    t.datetime "induction_start_date_submitted_to_trs_at"
     t.string "first_name", null: false
     t.string "last_name", null: false
     t.virtual "search", type: :tsvector, as: "to_tsvector('english'::regconfig, (((((COALESCE(first_name, ''::character varying))::text || ' '::text) || (COALESCE(last_name, ''::character varying))::text) || ' '::text) || (COALESCE(corrected_name, ''::character varying))::text))", stored: true
-    t.datetime "induction_start_date_submitted_to_trs_at"
     t.index ["corrected_name"], name: "index_teachers_on_corrected_name"
     t.index ["first_name", "last_name", "corrected_name"], name: "index_teachers_on_first_name_and_last_name_and_corrected_name", opclass: :gin_trgm_ops, using: :gin
     t.index ["search"], name: "index_teachers_on_search", using: :gin

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,30 @@
+namespace :db do
+  desc 'Add search config'
+  task setup_search_configuration: :environment do
+    Rails.logger.info("Setting up full text search unaccented configuration")
+    command = <<~SQL
+      create extension if not exists unaccent;
+
+      create text search configuration unaccented ( copy = simple );
+
+      alter text search configuration unaccented
+        alter mapping for hword, hword_part, word
+        with unaccent, simple;
+    SQL
+
+    Rails.logger.info("Adding full text search unaccented config to current env")
+    ActiveRecord::Base.connection.execute(command)
+
+    # NOTE: when we run this in the development env Rails automatically
+    #       creates the test database too, but not via `db:create` so
+    #       we need to ensure the text search config is applied there too
+    if Rails.env.development?
+      Rails.logger.info("Adding full text search unaccented config to test env")
+      ActiveRecord::Base.establish_connection(:test)
+      ActiveRecord::Base.connection.execute(command)
+      ActiveRecord::Base.establish_connection(:development)
+    end
+  end
+end
+
+Rake::Task['db:schema:load'].enhance(['db:setup_search_configuration'])

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -59,10 +59,10 @@ describe Teacher do
   describe 'scopes' do
     describe '#search' do
       it "searches the 'search' column using a tsquery" do
-        expect(Teacher.search('Joey').to_sql).to end_with(%{WHERE (teachers.search @@ websearch_to_tsquery('Joey'))})
+        expect(Teacher.search('Joey').to_sql).to end_with(%{WHERE (teachers.search @@ websearch_to_tsquery('unaccented', 'Joey'))})
       end
 
-      describe "matching" do
+      describe 'basic matching' do
         let!(:target) { FactoryBot.create(:teacher, first_name: "Malcolm", last_name: "Wilkerson", corrected_name: nil) }
         let!(:other) { FactoryBot.create(:teacher, first_name: "Reese", last_name: "Wilkerson", corrected_name: nil) }
 
@@ -78,6 +78,22 @@ describe Teacher do
 
           expect(results).to include(target)
           expect(results).not_to include(other)
+        end
+      end
+
+      describe 'matching with accents' do
+        let!(:target) { FactoryBot.create(:teacher, first_name: "Stëvìê", last_name: "Kènårbän", corrected_name: nil) }
+
+        it 'matches when names have accents but search terms do not' do
+          results = Teacher.search('Stevie Kenarban')
+
+          expect(results).to include(target)
+        end
+
+        it 'matches when names and search terms both have accents ' do
+          results = Teacher.search('Stëvìê Kènårbän')
+
+          expect(results).to include(target)
         end
       end
     end


### PR DESCRIPTION
The way we're searching uses a `search` field in the teachers table that contains the concatenated first_name, last_name and corrected_name fields in a tsvector (for full text indexing).

Unfortunately, this didn't work with accented characters like 'André'; we'd expect to be able to find that record with 'Andre'.

Initially we wanted to simply use [PostgreSQL's unaccent module](https://www.postgresql.org/docs/current/unaccent.html) to standardise the text. This ultimately didn't work because [unaccent is stable but not immutable](https://www.postgresql.org/message-id/flat/201012021544.oB2FiTn1041521@wwwmaster.postgresql.org#201012021544.oB2FiTn1041521@wwwmaster.postgresql.org).

Instead of taking the easy but slow route of just doing the conversions on the fly, this approach is a little more involved.

It won't make any difference in deployed environments where we always migrate rather than repeatedly drop/create/seed the database like we do in dev.

We can solve the problem by adding a new text search confuguration that applies the unaccent module, and use it to build the tsvector we index on.

Without switching from schema.rb to schema.sql, we can't do this as part of the migration but just need to make sure it's set up when the database is built.

The cleanest way to do this is to add a [rake task that enhances the `db:schema:load`](https://www.rubydoc.info/gems/rake/Rake/Task#enhance-instance_method) task by running the snippet of SQL before it. This ensures what we need is in place before creating the tables which depend on it.

Fixes #549 