### PR TITLE
Bump production and migration database plans and increase migration workers

### DIFF
--- a/config/terraform/application/config/migration.tfvars.json
+++ b/config/terraform/application/config/migration.tfvars.json
@@ -2,5 +2,8 @@
     "cluster": "production",
     "namespace": "cpd-production",
     "environment": "migration",
-    "enable_logit": true
+    "enable_logit": true,
+    "worker_replicas": 6,
+    "worker_memory_max": "2Gi",
+    "postgres_flexible_server_sku": "GP_Standard_D4ds_v4"
 }

--- a/config/terraform/application/config/migration.tfvars.json
+++ b/config/terraform/application/config/migration.tfvars.json
@@ -5,5 +5,5 @@
     "enable_logit": true,
     "worker_replicas": 6,
     "worker_memory_max": "2Gi",
-    "postgres_flexible_server_sku": "GP_Standard_D4ds_v4"
+    "postgres_flexible_server_sku": "GP_Standard_D4ds_v5"
 }

--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -6,7 +6,7 @@
     "enable_monitoring": false,
     "external_url": "https://ec2.production.teacherservices.cloud/healthcheck",
     "statuscake_contact_groups": [282453, 291418],
-    "postgres_flexible_server_sku": "GP_Standard_D4ds_v4",
+    "postgres_flexible_server_sku": "GP_Standard_D4ds_v5",
     "postgres_enable_high_availability": true,
     "azure_enable_backup_storage": true
 }

--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -5,5 +5,8 @@
     "enable_postgres_backup_storage" : true,
     "enable_monitoring": false,
     "external_url": "https://ec2.production.teacherservices.cloud/healthcheck",
-    "statuscake_contact_groups": [282453, 291418]
+    "statuscake_contact_groups": [282453, 291418],
+    "postgres_flexible_server_sku": "GP_Standard_D4ds_v4",
+    "postgres_enable_high_availability": true,
+    "azure_enable_backup_storage": true
 }

--- a/config/terraform/application/variables.tf
+++ b/config/terraform/application/variables.tf
@@ -93,15 +93,13 @@ variable "postgres_flexible_server_sku" {
   default = "B_Standard_B1ms"
 }
 
-variable "postgres_snapshot_flexible_server_sku" {
-  default = "B_Standard_B2ms"
-}
-
 variable "postgres_enable_high_availability" {
   type    = bool
   default = false
 }
+
 variable "enable_logit" { default = false }
+
 locals {
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 


### PR DESCRIPTION
See the individual commits for more of an explanation, but this is mainly adjusting the production database setup and:

* switching production from `B_Standard_B1ms` to `GP_Standard_D4ds_v4`
* enabling high availabilty mode
* enabling backup storage

We need the extra horsepower in the migration env because we're soon going to be running full migrations which are incredibly slow with the current setup.

In production our schedule changed. We originally intended to launch the service in late 2025/early 2026but now we need to deliver the Appropriate Body portal in Jan/Feb 2025, so we want to ensure our database properly configured with HA, backups etc. 

Fixes #523, #526, #607