### PR TITLE
Rename solid queue config and set queue priority

### DIFF
--- a/app/jobs/migration_job.rb
+++ b/app/jobs/migration_job.rb
@@ -1,5 +1,5 @@
 class MigrationJob < ApplicationJob
-  queue_as :high_priority
+  queue_as :migration
 
   def perform
     LegacyDataImporter.new.migrate!

--- a/app/jobs/migrator_job.rb
+++ b/app/jobs/migrator_job.rb
@@ -1,5 +1,5 @@
 class MigratorJob < ApplicationJob
-  queue_as :high_priority
+  queue_as :migration
 
   def perform(migrator:, worker:)
     migrator.migrate!(worker:)

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,7 @@ module Ecf2
     config.exceptions_app = routes
     config.active_record.belongs_to_required_by_default = false
     config.generators.system_tests = nil
+    config.action_mailer.deliver_later_queue_name = "mailers"
 
     config.generators do |g|
       g.helper(false)

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -3,7 +3,7 @@
      - polling_interval: 1
        batch_size: 500
    workers:
-     - queues: "*"
+     - queues: [ mailers, migration, "*" ]
        threads: 3
        processes: 3
        polling_interval: 0.1


### PR DESCRIPTION
Recently SolidQueue introduced a change that changed the default name for their configuration file. This PR renames the file  from `solifd_queue.yml` to `queue.yml` to match the new expected default 
Also I'm attempting to add a queue for `migration` and another for `mailers` and set their priority so that OTP password emails still get sent from the migration env when there's a ton of migration jobs queued and running