### PR TITLE
Make persona-based AB signin smoother

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,6 +12,10 @@ class SessionsController < ApplicationController
     # NOTE: OTP authentication is handled in OTPSessionsController as it is not omniauth
     case provider
     when "developer"
+      if params["appropriate_body_id"]
+        session["appropriate_body_id"] = params["appropriate_body_id"]
+      end
+
       session_manager.begin_session!(user_info.uid, provider)
     when "dfe"
       raise provider

--- a/app/helpers/personas_helper.rb
+++ b/app/helpers/personas_helper.rb
@@ -1,0 +1,11 @@
+module PersonasHelper
+  class PersonasNotAvailableError < StandardError; end
+
+  def appropriate_body_id_from_user_name(name)
+    fail(PersonasNotAvailableError) unless Rails.application.config.enable_personas
+
+    appropriate_bodies = AppropriateBody.pluck(:name, :id).to_h
+    appropriate_body_name = appropriate_bodies.keys.find { |ab_name| Regexp.compile(ab_name) =~ name }
+    appropriate_bodies[appropriate_body_name]
+  end
+end

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @personas.each do |persona| %>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-  <h2 class="govuk-heading-l"><%= persona.name %></h2>
+  <h2 class="govuk-heading-m"><%= persona.name %></h2>
   <div>
     <%# TODO: describe the persona e.g. what type of user, which org associations etc. %>
     <p><%= persona.email %></p>
@@ -11,6 +11,7 @@
   <%= form_with url: "/auth/developer/callback" do |f| %>
     <%= hidden_field_tag "email", persona.email %>
     <%= hidden_field_tag "name", persona.name %>
+    <%= hidden_field_tag "appropriate_body_id", appropriate_body_id_from_user_name(persona.name) %>
     <%= f.submit "Sign-in as #{persona.name}", class: "govuk-button govuk-!-margin-bottom-2" %>
   <% end %>
 <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -305,8 +305,10 @@ InductionExtension.create!(
 
 print_seed_info("Adding persona users")
 
-User.create!(name: "Velma Dinkley (AB)", email: "velma@example.com")
-User.create!(name: "Fred Jones (AB)", email: "freddy@example.com")
+# The appropriate body names are included in the AB user names as the persona
+# login process matches them and sets the session up correctly.
+User.create!(name: "Velma Dinkley (#{golden_leaf_academy.name} AB)", email: "velma@example.com")
+User.create!(name: "Fred Jones (#{umber_teaching_school_hub.name} AB)", email: "freddy@example.com")
 
 User.create!(name: "Daphne Blake (DfE staff)", email: "daphne@example.com").tap do |daphne_blake|
   DfERole.create!(user: daphne_blake)


### PR DESCRIPTION
Once we're integrated with DfE Sign-in we'll store the current appropriate_body_id for AB users in the session. When using personas for development and testing purposes, we don't really have a clean way of linking them.

This change adds the AB name to the seeds, and if the user signs in with a persona and that persona name contains the appropriate body's name it sets the session correctly.

It could be optimised further using a database query but we'll only have a handful of seed data so this should do for now.
