### PR TITLE
Add the release ECT behaviour

### DIFF
--- a/app/services/appropriate_bodies/release_ect.rb
+++ b/app/services/appropriate_bodies/release_ect.rb
@@ -1,15 +1,39 @@
 module AppropriateBodies
+  class ECTHasNoOngoingInductionPeriods < StandardError; end
+  class ECTHasMultipleOngoingInductionPeriods < StandardError; end
+
   class ReleaseECT
     def initialize(appropriate_body:, pending_induction_submission:)
       @appropriate_body = appropriate_body
       @pending_induction_submission = pending_induction_submission
+      @teacher = Teacher.find_by!(trn: pending_induction_submission.trn)
     end
 
     def release!
-      # FIXME: implement a proper release process here,
-      #        it probably needs to just close the current
-      #        open induction portal and write an event
-      true
+      InductionPeriod.transaction do
+        ongoing_induction_period.update(
+          finished_on: @pending_induction_submission.finished_on,
+          number_of_terms: @pending_induction_submission.number_of_terms
+        )
+
+        @pending_induction_submission.destroy!
+      end
+    end
+
+  private
+
+    def ongoing_induction_period
+      ongoing_induction_periods = InductionPeriod.ongoing.for_teacher(@teacher)
+
+      if ongoing_induction_periods.count.zero?
+        fail(ECTHasNoOngoingInductionPeriods, "TRN: #{@teacher.trn}")
+      end
+
+      if ongoing_induction_periods.count > 1
+        fail(ECTHasMultipleOngoingInductionPeriods, "TRN: #{@teacher.trn}")
+      end
+
+      ongoing_induction_periods.first
     end
   end
 end

--- a/spec/factories/pending_induction_submission_factory.rb
+++ b/spec/factories/pending_induction_submission_factory.rb
@@ -7,5 +7,10 @@ FactoryBot.define do
     trs_last_name { Faker::Name.last_name }
     started_on { 1.year.ago }
     trs_qts_awarded { 2.years.ago }
+
+    trait :finishing do
+      finished_on { 1.week.ago }
+      number_of_terms { 3 }
+    end
   end
 end

--- a/spec/services/appropriate_bodies/release_ect_spec.rb
+++ b/spec/services/appropriate_bodies/release_ect_spec.rb
@@ -45,5 +45,21 @@ describe AppropriateBodies::ReleaseECT do
       subject.release!
       expect(PendingInductionSubmission.where(id: pending_induction_submission.id)).to be_empty
     end
+
+    context "when an ECT has more than one ongoing induction period" do
+      it 'raises an error' do
+        induction_period.dup.save!(validate: false)
+
+        expect { subject.release! }.to raise_error(AppropriateBodies::ECTHasMultipleOngoingInductionPeriods)
+      end
+    end
+
+    context "when an ECT has no ongoing induction periods" do
+      it 'raises an error' do
+        induction_period.destroy!
+
+        expect { subject.release! }.to raise_error(AppropriateBodies::ECTHasNoOngoingInductionPeriods)
+      end
+    end
   end
 end

--- a/spec/services/appropriate_bodies/release_ect_spec.rb
+++ b/spec/services/appropriate_bodies/release_ect_spec.rb
@@ -1,0 +1,49 @@
+describe AppropriateBodies::ReleaseECT do
+  let(:induction_period) { FactoryBot.create(:induction_period, :active) }
+  let(:pending_induction_submission) do
+    FactoryBot.create(
+      :pending_induction_submission,
+      :finishing,
+      appropriate_body: induction_period.appropriate_body,
+      trn: induction_period.teacher.trn
+    )
+  end
+
+  subject do
+    AppropriateBodies::ReleaseECT.new(
+      appropriate_body: induction_period.appropriate_body,
+      pending_induction_submission:
+    )
+  end
+
+  describe 'initialization' do
+    it 'is initialized with an appropriate body and pending induction submission' do
+      expect(subject).to be_a(AppropriateBodies::ReleaseECT)
+    end
+
+    it 'sets assigns the right teacher' do
+      expect(subject.instance_variable_get(:@teacher)).to eql(induction_period.teacher)
+    end
+  end
+
+  describe 'release!' do
+    it 'closes the induction period setting the finished_on date and number_of_terms' do
+      expect(induction_period.number_of_terms).to be_blank
+      expect(induction_period.finished_on).to be_blank
+
+      subject.release!
+      induction_period.reload
+
+      expect(induction_period.number_of_terms).to be_present
+      expect(induction_period.finished_on).to be_present
+
+      expect(induction_period.number_of_terms).to eql(pending_induction_submission.number_of_terms)
+      expect(induction_period.finished_on).to eql(pending_induction_submission.finished_on)
+    end
+
+    it 'destroys the pending_induction_submission' do
+      subject.release!
+      expect(PendingInductionSubmission.where(id: pending_induction_submission.id)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
We just had a stub method until now. This implements the following behaviour:

* when an ECT is released the finished_on and number_of_terms values
  are written to the ongoing induction period
* the pending_induction_submission record is deleted
