### PR TITLE
Fix typo on public roadmap article + add context on ECF 1 and ECF 2

### DIFF
--- a/documentation/service-rules/appropriate-body-users.md
+++ b/documentation/service-rules/appropriate-body-users.md
@@ -2,14 +2,6 @@
 title: Appropriate bodies
 ---
 
-Learn about the services appropriate bodies use, and how the services allow appropriate bodies to carry out their duties. Services include the ‘appropriate body portal’ and the ‘check data for appropriate bodies’ service.  
-
-## Contents
-
-[Appropriate body portal](#appropriate-body-portal)
-
-[Check data for appropriate bodies](#check-data-for-appropriate-bodies)
-
 ## Appropriate body portal
 
 ### Get access to the TRA's appropriate body sign in
@@ -30,42 +22,6 @@ appropriate bodies. Policy outlining who can be an appropriate body:
 [Appropriate bodies guidance - section
 3:1](https://assets.publishing.service.gov.uk/media/661d459fac3dae9a53bd3de6/Appropriate_bodies_guidance_induction_and_the_early_career_framework.pdf)
 
-### View records for early career teachers that are already registered
-
-They (Appropriate Bodies) can view historical records for ECTs they have claimed in a list on their Appropriate body account homepage.
-
-They can also view their appropriate body ID. This is referred to later as an employer ID.
-
-### Individually claim an ECT for their induction status with the TRA
-
-The process of 'claiming' an ECT refers to an AB telling the TRA which ECTs they are quality assuring the induction of. 
-
-The appropriate body needs to enter both the date of birth and the TRN number for the ECT record to show up and be claimed.
-
-🔒 The AB needs both the TRN and DOB as a data privacy measure to ensure that the AB is only searching for ECTs they already have links with. This search locates the record in the database of qualified teachers (DQT).
-
-If there is no TRN and DOB match, then an error message appears. The AB would then liaise with our induction data collections team or the teacher themselves
-
-The record will still show but have a blank field in the QTS date section if they don't have QTS yet.
-
-If the ECT has previously failed induction, they cannot do induction again.
-
-📜 This is due to policy restricting those who have failed from reapplying to practice teaching. [AB
-guidance details this here.](https://assets.publishing.service.gov.uk/media/6629237f3b0122a378a7e6ef/Induction_for_early_career_teachers__England__statutory_guidance_.pdf)
-
-If an early career teacher did their initial teacher training (ITT) through an accredited ITT provider who is also an AB, the school cannot appoint that appropriate body for that teacher.
-
-ECTs may be serving their induction at an AB. For example, they may work at a teaching school hub that is also an AB. If this is the case, the school cannot appoint that AB for that teacher.
-
-📜 [Find out more in section 2 of the statutory guidance on induction for early career teachers.](https://www.gov.uk/government/publications/induction-for-early-career-teachers-england?)
-
-If an AB tries to claim an ECT who is exempt from the web UI, or via a
-bulk upload, it gives a message saying they are exempt.
-
-📜 Those who are exempt cannot be claimed as they don't need to be inducted
-in order to teach
-
-When the portal pulls up the record for the ECT, it would show:
 
 #### Status
 
@@ -147,96 +103,6 @@ another appropriate body, they would not be able to do this.
 
 🙋 This allows the TRA to keep track of where an ECT currently is or
 how many ECTs under an AB without overlaps in data.
-
-### Claiming an induction that is already claimed by another appropriate body
-
-When an appropriate body user tries to view an ECT record to claim them,
-if the ECT is already claimed by another appropriate body, it would
-state they were 'in progress' and the appropriate body they were in
-progress with.
-
-💻 They are unable to change this on the service so the appropriate
-body user would have to reach out to the other appropriate body or the
-TRA induction support team to get them to release the ECT.
-
-📜 Sometimes, these appropriate bodies (particularly local
-authorities due to policy changes) no longer exist so the induction
-support team would help the ABs to navigate this.
-
-### Claiming an ECT
-
-When they are claiming an ECT, the appropriate body user needs to state:
-
-1.  When the induction began for that ECT with that appropriate body
-
-2.  What type of induction programme they are doing (FIP, CIP, DIY)
-
-On 1, there is validation that makes sure the date given isn't
-before the date QTS was recorded. This is because induction should only
-start after they received QTS.
-
-There are some discrepancies in the rules on the portal. Future dates
-aren't allowed in the web update, but can get through the bulk
-import upload.
-
-The end date of an induction period must be after the start date for an induction period.
-
-When this data is submitted, the appropriate body user would see the
-employer ID and employer address. This is the same as the appropriate
-body ID, and should show the appropriate body address.
-
-### Release an ECT so another school can claim them or because the ECT dropped out of teaching
-
-An appropriate body user can record an induction outcome of not yet
-completed when they click to update induction details. 'Not yet
-completed' means they did not finish their induction but are no longer
-with that appropriate body.
-
-When they do this, they must:
-
-- Confirm or update the induction start date for the ECT with their appropriate body -- this is auto populated from what they previously gave when first claiming the ECT but can be edited if needed
-- Give the induction end date for when the ECT stopped induction with their appropriate body
-- Give the number of terms served as a whole number. The number of terms can only be given at the point an outcome so this part isn't auto-populated and would need to be input
-- Confirm or update the induction programme type -- this is populated from what they previously gave
-
-They would submit that and then it would update DQT.
-
-'Not yet completed' is the only status option for an ECT leaving an AB
-regardless of the circumstances.
-
-If an ECT drops out of teaching, the appropriate body does not update
-the ECT's record any differently to when they would release an ECT who
-had changed appropriate body for their induction. The record just
-remains as 'not yet completed'.
-
-Sometimes, ECTs will potentially come back and finish induction
-much later therefore keeping their record as not yet completed
-regardless of reasons for leaving allows their record to be picked up
-from where it was last updated.
-
-### Pass or fail an ECT's induction 
-
-This would be under where AB users 5ecord an induction outcome.
-
-The following data points are given, updated or confirmed for this:
-
--   Dates of when induction started and ended
-
--   Number of terms completed
-
--   Induction programme type
-
-📊📜 This is the data that's needed by the DQT to be on the record when giving
-an ECT an outcome
-
-There is validation to not allow future dates or induction end date before the induction start date.
-
-This is not the case when done in a mass upload as the DQT processes
-mass upload data overnight.
-
-💻 This is because the system can't correct errors with validation
-rules as it's done on a template and will simply bounce them back a day
-after the upload once processed.
 
 ### Extend an ECT's induction
 

--- a/documentation/service-rules/claim-an-ect.md
+++ b/documentation/service-rules/claim-an-ect.md
@@ -1,0 +1,52 @@
+---
+title: Claim an ECT
+---
+
+Claiming an ECT is when an appropriate body informs the TRA whose induction they're quality assuring. They can do this using the 'appropriate body portal'.
+
+They need to enter the ECT's:
+
+- date of birth 🔒
+- teacher reference number 🔒
+
+This ensures that the AB only searches for ECTs they already have links with. The search locates the record in the database of qualified teachers (DQT).
+
+If there is no TRN and DOB match, then an error message appears. The AB would then liaise with our induction data collections team or the teacher themselves.
+
+When they claiming an ECT, the appropriate body also needs to enter the:
+
+* induction start date
+* type of programme (FIP, CIP, DIY)
+
+When this data is submitted, the appropriate body user would see the employer ID and employer address. This is the same as the appropriate body ID, and should show the appropriate body address.
+
+### Validation and issues with the appropriate body portal 💻
+
+There is validation to make sure the induction start date is not before the ECT's QTS date. Induction should only start after the ECT has received QTS. If the ECT does not have QTS yet, the record will still show but there will be a blank field in the QTS date section.
+
+There are some discrepancies in the rules on the portal. Future dates aren't allowed in the web update, but can get through the bulk import upload.
+
+The end date of an induction period must be after the start date for an induction period.
+
+If an AB tries to claim an ECT who is exempt from the web UI, or via a bulk upload, it gives a message saying they are exempt. Those who are exempt cannot be claimed as they don't need to be inducted in order to teach.
+
+### Claiming an ECT who is already claimed
+
+When an appropriate body user tries to view an ECT record to claim them,
+if the ECT is already claimed by another appropriate body, it would
+state they were 'in progress' and the appropriate body they were in
+progress with.
+
+💻 They are unable to change this on the service so the appropriate
+body user would have to reach out to the other appropriate body or the
+TRA induction support team to get them to release the ECT.
+
+📜 Sometimes, these appropriate bodies (particularly local
+authorities due to policy changes) no longer exist so the induction
+support team would help the ABs to navigate this.
+
+### Policy caveats relating to claiming an ECT 📜
+
+An ECT cannot do induction if they previously failed it. [Policy states that those who have failed cannot reapply to practice teaching](https://assets.publishing.service.gov.uk/media/6629237f3b0122a378a7e6ef/Induction_for_early_career_teachers__England__statutory_guidance_.pdf).
+
+[There are rules about who schools can and cannot appoint as an appropriate body](https://www.gov.uk/guidance/managing-training-for-early-career-teachers#appointing-an-appropriate-body).

--- a/documentation/service-rules/pass-or-fail-induction.md
+++ b/documentation/service-rules/pass-or-fail-induction.md
@@ -1,0 +1,15 @@
+An appropriate body can use the 'appropriate body portal' to record an induction outcome.
+
+They need to confirm or update:
+
+-   when induction started and ended
+-   number of terms completed
+-   induction programme type
+
+📊📜 This is the requirement for the DQT record.
+
+There is validation to not allow future dates or an induction end date before the induction start date.
+
+This is not the case when done in a mass upload as the DQT processes mass upload data overnight.
+
+💻 This is because the system can't correct errors with validation rules as it's done on a template and will simply bounce them back a day after the upload once processed.

--- a/documentation/service-rules/release-an-ect.md
+++ b/documentation/service-rules/release-an-ect.md
@@ -1,0 +1,24 @@
+---
+title: Release an ECT
+---
+
+An appropriate body can release an ECT so that another school can claim them, or because the ECT dropped out of teaching.
+
+They can also record an induction outcome of 'not yet completed' when they click to update induction details. 
+
+'Not yet completed' means they did not finish their induction with that appropriate body.
+
+Appropriate bodies need to provide the:
+
+- induction start date - this is populated from what they previously gave when first claiming the ECT but can be edited
+- induction end date
+- number of terms served as a whole number - this can only be given at the point an outcome so is not already populated
+- the induction programme type - this is populated from what they previously gave but can be edited 
+
+Submitting this information updates the DQT.
+
+'Not yet completed' is the only status option for an ECT leaving an AB regardless of the circumstances.
+
+If an ECT drops out of teaching, the appropriate body does not update the ECT's record any differently. The record just remains as 'not yet completed'.
+
+Sometimes, ECTs come back and finish induction much later. Their record stays as 'not yet completed' regardless of the reason why they left. This allows their record to be updated again in the future.

--- a/documentation/service-rules/view-appropriate-body-id.md
+++ b/documentation/service-rules/view-appropriate-body-id.md
@@ -1,0 +1,5 @@
+---
+title: Check their ID
+---
+
+Appropriate bodies can view their appropriate body ID, also referred to as an employer ID, using the 'appropriate body' portal.

--- a/documentation/service-rules/view-ect-records.md
+++ b/documentation/service-rules/view-ect-records.md
@@ -1,0 +1,7 @@
+---
+title: View ECT records
+---
+
+Appropriate bodies can view records for their registered early career teachers using the 'appropriate body' portal.
+
+They can see also see historial records for their ECTs on their account homepage.

--- a/documentation/site/content/stylesheet.scss
+++ b/documentation/site/content/stylesheet.scss
@@ -49,8 +49,12 @@ $govuk-assets-path: "/";
     }
 }
 
-.service-rules {
-    > p:first-of-type {
-        @include govuk-font($size: 24);
-    }
+// .service-rules {
+//     > p:first-of-type {
+//         @include govuk-font($size: 24);
+//     }
+// }
+
+.govuk-list ul {
+    padding-left: 20px; /* Adjust as necessary for desired indentation */
 }

--- a/documentation/site/layouts/service-rules.html
+++ b/documentation/site/layouts/service-rules.html
@@ -9,18 +9,31 @@
       <main class="govuk-main-wrapper" id="main-content">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <span class="govuk-caption-xl">Service rules</span>
+            <span class="govuk-caption-xl">Appropriate bodies</span>
             <h1 class="govuk-heading-xl"><%= item[:title] %></h1>
           </div>
         </div>
         <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-third">
+            <ul class="govuk-list">
+              <li><strong>What different users can do using the ECT services</strong></li>
+              <li>
+                <%= link_to "Appropriate bodies", "/service-rules/appropriate-body-users/" %>
+                <ul class="govuk-list">
+                  <li><%= link_to "View ECT records", "/service-rules/view-ect-records/" %></li>
+                  <li><%= link_to "Check their ID", "/service-rules/view-appropriate-body-id/" %></li>
+                  <li><%= link_to "Claim an ECT", "/service-rules/claim-an-ect/" %></li></li>
+                  <li><%= link_to "Release an ECT", "/service-rules/release-an-ect/" %></li></li>
+                  <li><%= link_to "Pass or fail an ECT's induction", "/service-rules/pass-or-fail-induction/" %></li></li>
+                </ul>
+              </li>
+            </ul>
+            <%= render '/partials/key.*' %>
+          </div>
           <div class="govuk-grid-column-two-thirds">
             <article class="service-rules">
               <%= yield %>
             </article>
-          </div>
-          <div class="govuk-grid-column-one-third">
-            <%= render '/partials/key.*' %>
           </div>
         </div>
       </main>

--- a/documentation/site/lib/helpers.rb
+++ b/documentation/site/lib/helpers.rb
@@ -1,1 +1,2 @@
 use_helper Nanoc::Helpers::Rendering
+use_helper Nanoc::Helpers::LinkTo


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e22ef1b7-1d59-4e8e-b3da-4de858c95a09)

Change to money spent and add ECF 1 / 2 explainer - as we refer to ECF 2 but don't explain what it is. 