### PR TITLE
Fix typos and add ECF1 / 2 explainer in public roadmap article 

### DIFF
--- a/documentation/site/content/product/roadmap/introduction.md
+++ b/documentation/site/content/product/roadmap/introduction.md
@@ -18,7 +18,7 @@ All of these items of work are related to our objectives as a team. Our objectiv
 3. Better meet lead provider needs by showing the right data over the Lead provider API, improving documentation and updating validation rules ☁️
 4. Improve understanding of financial information internally and make sure payments are calculated correctly 💰
 5. Ensure the successful development of the Register early career teacher services by planning for dependencies, risks and communications 🗒️
-6. Minimise time and money sent on support tasks by creating improved joint support and finance tooling 🦸
+6. Minimise time and money spent on support tasks by creating improved joint support and finance tooling 🦸
 7. Improve how data on ECF is reported and create performance metrics for the new Register early career teachers services 📊
 8. Reduce confusion for users by helping them understand how the Register early career teacher services are structured, the service's purposes and their own responsibilities ✏️
 9. Build services that are safe, protect privacy and are tested and documented well 🔨

--- a/documentation/site/content/product/roadmap/now.md
+++ b/documentation/site/content/product/roadmap/now.md
@@ -4,4 +4,4 @@
 * improving how an early career teacher or mentor is registered, so we save schools time and improve data accuracy
 * improving how records for ECTs and mentors are viewed, so we can remind them of essential actions they need to take and can make changes to records easily
 * designing a prototype and setting up the infrastructure for a service where appropriate bodies can submit induction data, so we improve the accuracy of our data and can later consolidate registration for schools
-* setting up processes for how we will migrate data from the legacy service to our new service, so that we can migrate data from ECF1 to ECF2 efficiently and cleanly
+* setting up processes for how we will migrate data from the legacy service to our new service, so that we can migrate data from ECF1 to ECF2 efficiently and cleanly. ECF1 is the current service, ECF 2 is the future service this team is designing and building. 

--- a/documentation/site/content/product/roadmap/now.md
+++ b/documentation/site/content/product/roadmap/now.md
@@ -4,4 +4,4 @@
 * improving how an early career teacher or mentor is registered, so we save schools time and improve data accuracy
 * improving how records for ECTs and mentors are viewed, so we can remind them of essential actions they need to take and can make changes to records easily
 * designing a prototype and setting up the infrastructure for a service where appropriate bodies can submit induction data, so we improve the accuracy of our data and can later consolidate registration for schools
-* setting up processes for how we will migrate data from the legacy service to our new service, so that we can migrate data from ECF1 to ECF2 efficiently and cleanly. ECF1 is the current service, ECF 2 is the future service this team is designing and building. 
+* setting up processes for how we will migrate data from the legacy service to our new service, so that we can migrate data from ECF1 to ECF2 efficiently and cleanly. ECF1 is the current set of services for managing training and induction for early career teachers. ECF 2 is the future service that will replace and improve upon ECF1.


### PR DESCRIPTION
### Why 

There was a typo and a reference to ECF 1 and 2 that didn't explain what they were. 

### What 

Tweaked the copy to fix this and make it clearer. 

Screenshots of before are below. 

Sent - spent 

![image](https://github.com/user-attachments/assets/4aca5267-50bd-4d01-a68c-57d989664070)

ECF 1 and ECF 2 

![image](https://github.com/user-attachments/assets/3f1f0bbf-28e2-44b5-83d2-1db5651be78f)

