### PR TITLE
Fix refs for migrated data

### DIFF
--- a/app/migration/builders/teacher.rb
+++ b/app/migration/builders/teacher.rb
@@ -1,14 +1,15 @@
 module Builders
   class Teacher
-    attr_reader :trn, :full_name
+    attr_reader :trn, :full_name, :legacy_id
 
-    def initialize(trn:, full_name:)
+    def initialize(trn:, full_name:, legacy_id: nil)
       @trn = trn
       @full_name = full_name
+      @legacy_id = legacy_id
     end
 
     def process!
-      ::Teacher.create!(trn:, first_name: parser.first_name, last_name: parser.last_name)
+      ::Teacher.create!(trn:, first_name: parser.first_name, last_name: parser.last_name, legacy_id:)
     end
 
   private

--- a/app/migration/migrators/teacher.rb
+++ b/app/migration/migrators/teacher.rb
@@ -28,7 +28,7 @@ module Migrators
       trn = teacher_profile.trn
       full_name = teacher_profile.user.full_name
 
-      teacher = Builders::Teacher.new(trn:, full_name:).process!
+      teacher = Builders::Teacher.new(trn:, full_name:, legacy_id: teacher_profile.user_id).process!
 
       teacher_profile
         .participant_profiles
@@ -44,9 +44,11 @@ module Migrators
           if participant_profile.ect?
             Builders::ECT::SchoolPeriods.new(teacher:, school_periods:).process!
             Builders::ECT::TrainingPeriods.new(teacher:, training_period_data:).process!
+            teacher.update!(legacy_ect_id: participant_profile.id)
           else
             Builders::Mentor::SchoolPeriods.new(teacher:, school_periods:).process!
             Builders::Mentor::TrainingPeriods.new(teacher:, training_period_data:).process!
+            teacher.update!(legacy_mentor_id: participant_profile.id)
           end
         end
     end

--- a/app/migration/migrators/teacher.rb
+++ b/app/migration/migrators/teacher.rb
@@ -12,6 +12,10 @@ module Migrators
       ::Migration::TeacherProfile.where(id: ::Migration::ParticipantProfile.ect_or_mentor.select(:teacher_profile_id).distinct)
     end
 
+    def self.dependencies
+      %i[provider_partnership]
+    end
+
     def self.reset!
       if Rails.application.config.enable_migration_testing
         ::Teacher.connection.execute("TRUNCATE #{::Teacher.table_name} RESTART IDENTITY CASCADE")

--- a/db/migrate/20241115110325_add_legacy_profile_ids_to_teacher.rb
+++ b/db/migrate/20241115110325_add_legacy_profile_ids_to_teacher.rb
@@ -1,0 +1,8 @@
+class AddLegacyProfileIdsToTeacher < ActiveRecord::Migration[7.2]
+  def change
+    change_table :teachers, bulk: true do |t|
+      t.uuid :legacy_ect_id
+      t.uuid :legacy_mentor_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_07_154521) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_15_110325) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -382,6 +382,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_154521) do
     t.string "last_name", null: false
     t.virtual "search", type: :tsvector, as: "to_tsvector('unaccented'::regconfig, (((((COALESCE(first_name, ''::character varying))::text || ' '::text) || (COALESCE(last_name, ''::character varying))::text) || ' '::text) || (COALESCE(corrected_name, ''::character varying))::text))", stored: true
     t.uuid "legacy_id"
+    t.uuid "legacy_ect_id"
+    t.uuid "legacy_mentor_id"
     t.index ["corrected_name"], name: "index_teachers_on_corrected_name"
     t.index ["first_name", "last_name", "corrected_name"], name: "index_teachers_on_first_name_and_last_name_and_corrected_name", opclass: :gin_trgm_ops, using: :gin
     t.index ["search"], name: "index_teachers_on_search", using: :gin

--- a/spec/migration/builders/teacher_spec.rb
+++ b/spec/migration/builders/teacher_spec.rb
@@ -26,6 +26,15 @@ describe Builders::Teacher do
       expect(teacher.last_name).to eq "Thompson"
     end
 
+    context "when a legacy_id is supplied" do
+      let(:legacy_id) { SecureRandom.uuid }
+
+      it "stores the legacy_id" do
+        teacher = described_class.new(trn:, full_name:, legacy_id:).process!
+        expect(teacher.legacy_id).to eq legacy_id
+      end
+    end
+
     context "when a teacher with the same TRN already exists" do
       before do
         FactoryBot.create(:teacher, trn:)


### PR DESCRIPTION
Realised that we're no longer storing the legacy_id on migrated `Teacher` after my last PR. This fixes that and also adds 2 new legacy IDs to record the ECT and/or Mentor ParticipantProfile source IDs during migration.
Also add a migration dependency to `Teacher` for `ProviderPartnership` so that we can create `TrainingPeriod` records.