### PR TITLE
Fix email content in validation

### DIFF
--- a/app/wizards/schools/register_ect/email_address_step.rb
+++ b/app/wizards/schools/register_ect/email_address_step.rb
@@ -5,7 +5,7 @@ module Schools
     class EmailAddressStep < StoredStep
       attr_accessor :email
 
-      validates :email, presence: { message: "Enter your email address" }, notify_email: true
+      validates :email, presence: { message: "Enter the email address" }, notify_email: true
 
       def self.permitted_params
         %i[email]


### PR DESCRIPTION
It should read 'the email address', not 'your email address', as the email is not for the user, but for the ECT or mentor they're registering.