### PR TITLE
Fix a bug in migrator

### DIFF
--- a/app/migration/builders/ect/training_periods.rb
+++ b/app/migration/builders/ect/training_periods.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 module Builders
   module ECT
     class TrainingPeriods
@@ -16,7 +18,7 @@ module Builders
                                                              delivery_partner: ::DeliveryPartner.find_by!(name: period.delivery_partner),
                                                              academic_year_id: period.cohort_year).first
 
-          period_dates = OpenStruct.new(started_on: period.start_date, finished_on: period.end_date)
+          period_dates = ::OpenStruct.new(started_on: period.start_date, finished_on: period.end_date)
           ect_at_school_period = teacher.ect_at_school_periods.containing_period(period_dates).first
 
           ::TrainingPeriod.create!(provider_partnership:,

--- a/app/migration/builders/ect/training_periods.rb
+++ b/app/migration/builders/ect/training_periods.rb
@@ -1,5 +1,3 @@
-require "ostruct"
-
 module Builders
   module ECT
     class TrainingPeriods
@@ -11,6 +9,8 @@ module Builders
       end
 
       def process!
+        period_date = Data.define(:started_on, :finished_on)
+
         training_period_data.each do |period|
           next unless period.training_programme == "full_induction_programme"
 
@@ -18,7 +18,7 @@ module Builders
                                                              delivery_partner: ::DeliveryPartner.find_by!(name: period.delivery_partner),
                                                              academic_year_id: period.cohort_year).first
 
-          period_dates = ::OpenStruct.new(started_on: period.start_date, finished_on: period.end_date)
+          period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           ect_at_school_period = teacher.ect_at_school_periods.containing_period(period_dates).first
 
           ::TrainingPeriod.create!(provider_partnership:,

--- a/app/migration/builders/mentor/training_periods.rb
+++ b/app/migration/builders/mentor/training_periods.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 module Builders
   module Mentor
     class TrainingPeriods
@@ -16,7 +18,7 @@ module Builders
                                                              delivery_partner: ::DeliveryPartner.find_by!(name: period.delivery_partner),
                                                              academic_year_id: period.cohort_year).first
 
-          period_dates = OpenStruct.new(started_on: period.start_date, finished_on: period.end_date)
+          period_dates = ::OpenStruct.new(started_on: period.start_date, finished_on: period.end_date)
           mentor_at_school_period = teacher.mentor_at_school_periods.containing_period(period_dates).first
 
           ::TrainingPeriod.create!(provider_partnership:,

--- a/app/migration/builders/mentor/training_periods.rb
+++ b/app/migration/builders/mentor/training_periods.rb
@@ -1,5 +1,3 @@
-require "ostruct"
-
 module Builders
   module Mentor
     class TrainingPeriods
@@ -11,6 +9,8 @@ module Builders
       end
 
       def process!
+        period_date = Data.define(:started_on, :finished_on)
+
         training_period_data.each do |period|
           next unless period.training_programme == "full_induction_programme"
 
@@ -18,7 +18,7 @@ module Builders
                                                              delivery_partner: ::DeliveryPartner.find_by!(name: period.delivery_partner),
                                                              academic_year_id: period.cohort_year).first
 
-          period_dates = ::OpenStruct.new(started_on: period.start_date, finished_on: period.end_date)
+          period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           mentor_at_school_period = teacher.mentor_at_school_periods.containing_period(period_dates).first
 
           ::TrainingPeriod.create!(provider_partnership:,


### PR DESCRIPTION
The `TrainingPeriod` builders use `OpenStruct` to find the correct school period to which they belong. However this means we need to `require "ostruct"` before using it.