### PR TITLE
School user is unable to match an ECT's TRN with a TRS record

### DIFF
--- a/app/components/test_guidance_component.rb
+++ b/app/components/test_guidance_component.rb
@@ -37,7 +37,7 @@ class TestGuidanceComponent < ViewComponent::Base
       tag.button 'Select',
                  class: 'govuk-button govuk-button--secondary govuk-button--small populate-find-ect-form-button',
                  type: 'button',
-                 data: { trn:, dob:, nationalNationalInsuranceNumber: national_insurance_number }
+                 data: { trn:, dob:, national_insurance_number: }
     end
 
     def call

--- a/app/views/schools/register_ect/not_found.html.erb
+++ b/app/views/schools/register_ect/not_found.html.erb
@@ -4,4 +4,4 @@
 <p class="govuk-body">You can check their TRN by <%= govuk_link_to('reviewing their teacher record', 'https://check-a-teachers-record.education.gov.uk/check-records/sign-in') %>.</p>
 <p class="govuk-body">Alternatively, you can ask the ECT to check their TRN by using the <%= govuk_link_to('Find a lost TRN service', 'https://find-a-lost-trn.education.gov.uk/start') %>.</p>
 
-<%= govuk_button_link_to("Try again", schools_register_ect_start_path) %>
+<%= govuk_button_link_to("Try again", schools_register_ect_find_ect_path) %>

--- a/app/views/schools/register_ect/not_found.html.erb
+++ b/app/views/schools/register_ect/not_found.html.erb
@@ -1,7 +1,7 @@
-<% page_data(title: "We were unable to match your ECT's details", error: false) %>
+<% page_data(title: "We're unable to match the ECT with the details you provided", error: false) %>
 
-<p class="govuk-body">We cannot find a match with the details you've provided.</p>
-<p class="govuk-body">You can check the ECT's teacher reference number (TRN) is accurate by <%= govuk_link_to('reviewing their teacher record', 'https://check-a-teachers-record.education.gov.uk/check-records/sign-in') %>.</p>
+<p class="govuk-body">Check that you've entered their details correctly.</p>
+<p class="govuk-body">You can check their TRN by <%= govuk_link_to('reviewing their teacher record', 'https://check-a-teachers-record.education.gov.uk/check-records/sign-in') %>.</p>
 <p class="govuk-body">Alternatively, you can ask the ECT to check their TRN by using the <%= govuk_link_to('Find a lost TRN service', 'https://find-a-lost-trn.education.gov.uk/start') %>.</p>
 
-<%= govuk_button_link_to("Try again", schools_register_ect_find_ect_path) %>
+<%= govuk_button_link_to("Try again", schools_register_ect_start_path) %>

--- a/app/views/schools/register_ect/trn_not_found.html.erb
+++ b/app/views/schools/register_ect/trn_not_found.html.erb
@@ -3,4 +3,4 @@
 <p class="govuk-body">You can check their TRN by <%= govuk_link_to('reviewing their teacher record', 'https://check-a-teachers-record.education.gov.uk/check-records/sign-in') %>.</p>
 <p class="govuk-body">Alternatively, you can ask the ECT to check their TRN by using the <%= govuk_link_to('Find a lost TRN service', 'https://find-a-lost-trn.education.gov.uk/start') %>.</p>
 
-<%= govuk_button_link_to("Try again", schools_register_ect_start_path) %>
+<%= govuk_button_link_to("Try again", schools_register_ect_find_ect_path) %>

--- a/app/views/schools/register_ect/trn_not_found.html.erb
+++ b/app/views/schools/register_ect/trn_not_found.html.erb
@@ -1,0 +1,6 @@
+<% page_data(title: "We're unable to match the ECT with the TRN you provided", error: false) %>
+
+<p class="govuk-body">You can check their TRN by <%= govuk_link_to('reviewing their teacher record', 'https://check-a-teachers-record.education.gov.uk/check-records/sign-in') %>.</p>
+<p class="govuk-body">Alternatively, you can ask the ECT to check their TRN by using the <%= govuk_link_to('Find a lost TRN service', 'https://find-a-lost-trn.education.gov.uk/start') %>.</p>
+
+<%= govuk_button_link_to("Try again", schools_register_ect_start_path) %>

--- a/app/wizards/schools/register_ect/ect.rb
+++ b/app/wizards/schools/register_ect/ect.rb
@@ -18,12 +18,6 @@ module Schools
 
         trs_date_of_birth.to_date == date_of_birth.to_date
       end
-
-      def matches_trs_trn
-        return false if [trn, trs_trn].any?(&:blank?)
-
-        trn == trs_trn
-      end
     end
   end
 end

--- a/app/wizards/schools/register_ect/ect.rb
+++ b/app/wizards/schools/register_ect/ect.rb
@@ -18,6 +18,12 @@ module Schools
 
         trs_date_of_birth.to_date == date_of_birth.to_date
       end
+
+      def matches_trs_trn
+        return false if [trn, trs_trn].any?(&:blank?)
+
+        trn == trs_trn
+      end
     end
   end
 end

--- a/app/wizards/schools/register_ect/find_ect_step.rb
+++ b/app/wizards/schools/register_ect/find_ect_step.rb
@@ -13,8 +13,9 @@ module Schools
       end
 
       def next_step
-        return :not_found unless ect.in_trs?
+        return :trn_not_found unless ect.matches_trs_trn
         return :national_insurance_number unless ect.matches_trs_dob?
+        return :not_found unless ect.in_trs?
 
         :review_ect_details
       end
@@ -26,6 +27,7 @@ module Schools
                    date_of_birth: date_of_birth.values.join("-"),
                    trs_national_insurance_number: trs_teacher.national_insurance_number,
                    trs_date_of_birth: trs_teacher.date_of_birth,
+                   trs_trn: trs_teacher.trn,
                    trs_first_name: trs_teacher.first_name,
                    trs_last_name: trs_teacher.last_name)
       end

--- a/app/wizards/schools/register_ect/find_ect_step.rb
+++ b/app/wizards/schools/register_ect/find_ect_step.rb
@@ -13,9 +13,8 @@ module Schools
       end
 
       def next_step
-        return :trn_not_found unless ect.matches_trs_trn
+        return :trn_not_found unless ect.in_trs?
         return :national_insurance_number unless ect.matches_trs_dob?
-        return :not_found unless ect.in_trs?
 
         :review_ect_details
       end

--- a/app/wizards/schools/register_ect/trn_not_found_step.rb
+++ b/app/wizards/schools/register_ect/trn_not_found_step.rb
@@ -1,0 +1,6 @@
+module Schools
+  module RegisterECT
+    class TRNNotFoundStep < Step
+    end
+  end
+end

--- a/app/wizards/schools/register_ect/wizard.rb
+++ b/app/wizards/schools/register_ect/wizard.rb
@@ -15,6 +15,7 @@ module Schools
             national_insurance_number: NationalInsuranceNumberStep,
             not_found: NotFoundStep,
             review_ect_details: ReviewECTDetailsStep,
+            trn_not_found: TRNNotFoundStep,
           }
         ]
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,8 @@ Rails.application.routes.draw do
       get "national-insurance-number", action: :new
       post "national-insurance-number", action: :create
 
+      get "trn-not-found", action: :new
+
       get "not-found", action: :new
 
       get "review-ect-details", action: :new

--- a/spec/features/schools/register_an_ect/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
+++ b/spec/features/schools/register_an_ect/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe 'Registering an ECT' do
 
     when_i_enter_a_national_insurance_number_that_does_not_match
     then_i_should_be_taken_to_the_teacher_not_found_error_page
+
+    when_i_click_try_again
+    then_i_should_be_taken_to_the_find_ect_step_page
   end
 
   def given_there_is_a_school_in_the_service
@@ -68,5 +71,14 @@ RSpec.describe 'Registering an ECT' do
 
   def then_i_should_be_taken_to_the_teacher_not_found_error_page
     expect(page.url).to end_with('/schools/register-ect/not-found')
+  end
+
+  def when_i_click_try_again
+    page.get_by_role('link', name: 'Try again').click
+  end
+
+  def then_i_should_be_taken_to_the_find_ect_step_page
+    path = '/schools/register-ect/find-ect'
+    expect(page.url).to end_with(path)
   end
 end

--- a/spec/features/schools/register_an_ect/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
+++ b/spec/features/schools/register_an_ect/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Registering an ECT' do
     sign_in_as_admin
   end
 
-  scenario 'Teacher is not found' do
+  scenario 'Teacher with national insurance number is not found' do
     given_there_is_a_school_in_the_service
     and_i_am_on_the_schools_landing_page
     when_i_start_adding_an_ect

--- a/spec/features/schools/register_an_ect/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/register_an_ect/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe 'Registering an ECT' do
     given_i_am_on_the_find_ect_step_page
     and_i_submit_a_date_of_birth_and_unknown_trn
     then_i_should_be_taken_to_the_teacher_not_found_error_page
+
+    when_i_click_try_again
+    then_i_should_be_taken_to_the_find_ect_step_page
   end
 
   def given_i_am_on_the_find_ect_step_page
@@ -29,6 +32,15 @@ RSpec.describe 'Registering an ECT' do
 
   def then_i_should_be_taken_to_the_teacher_not_found_error_page
     path = '/schools/register-ect/trn-not-found'
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_click_try_again
+    page.get_by_role('link', name: 'Try again').click
+  end
+
+  def then_i_should_be_taken_to_the_find_ect_step_page
+    path = '/schools/register-ect/find-ect'
     expect(page.url).to end_with(path)
   end
 end

--- a/spec/features/schools/register_an_ect/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/register_an_ect/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe 'Registering an ECT' do
+  include_context 'fake trs api client that finds nothing'
+
+  let(:page) { RSpec.configuration.playwright_page }
+
+  before do
+    sign_in_as_admin
+  end
+
+  scenario 'Teacher with TRN is not found' do
+    given_i_am_on_the_find_ect_step_page
+    and_i_submit_a_date_of_birth_and_unknown_trn
+    then_i_should_be_taken_to_the_teacher_not_found_error_page
+  end
+
+  def given_i_am_on_the_find_ect_step_page
+    path = '/schools/register-ect/find-ect'
+    page.goto path
+    expect(page.url).to end_with(path)
+  end
+
+  def and_i_submit_a_date_of_birth_and_unknown_trn
+    page.get_by_label('trn').fill('9876543')
+    page.get_by_label('day').fill('1')
+    page.get_by_label('month').fill('2')
+    page.get_by_label('year').fill('1980')
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_teacher_not_found_error_page
+    path = '/schools/register-ect/trn-not-found'
+    expect(page.url).to end_with(path)
+  end
+end


### PR DESCRIPTION
### Ticket
#685 

### Changes

Redirect the user to the Teacher Not Found page if they attempt to register an ECT with an unknown TRN

### Vid

https://github.com/user-attachments/assets/b8cb5ec3-6d1f-44ed-a0fb-97cddaecd0bc
