### PR TITLE
Migrate mentorships

### DIFF
--- a/app/migration/builders/mentorship_periods.rb
+++ b/app/migration/builders/mentorship_periods.rb
@@ -1,0 +1,32 @@
+module Builders
+  class MentorshipPeriods
+    attr_reader :teacher, :mentorship_period_data
+
+    def initialize(teacher:, mentorship_period_data:)
+      @teacher = teacher
+      @mentorship_period_data = mentorship_period_data
+    end
+
+    def process!
+      period_date = Data.define(:started_on, :finished_on)
+
+      mentorship_period_data.each do |period|
+        period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
+        teacher_period = teacher.ect_at_school_periods.containing_period(period_dates).first
+        raise ActiveRecord::RecordNotFound, "No ECTAtSchoolPeriod found for mentorship dates" if teacher_period.nil?
+
+        mentor_period = period.mentor_teacher.mentor_at_school_periods
+          .where(school_id: teacher_period.school_id)
+          .containing_period(period_dates).first
+        raise ActiveRecord::RecordNotFound, "No MentorAtSchoolPeriod found for mentorship dates" if mentor_period.nil?
+
+        ::MentorshipPeriod.create!(mentee: teacher_period,
+                                   mentor: mentor_period,
+                                   started_on: period.start_date,
+                                   finished_on: period.end_date,
+                                   legacy_start_id: period.start_source_id,
+                                   legacy_end_id: period.end_source_id)
+      end
+    end
+  end
+end

--- a/app/migration/builders/mentorship_periods.rb
+++ b/app/migration/builders/mentorship_periods.rb
@@ -15,6 +15,8 @@ module Builders
         teacher_period = teacher.ect_at_school_periods.containing_period(period_dates).first
         raise ActiveRecord::RecordNotFound, "No ECTAtSchoolPeriod found for mentorship dates" if teacher_period.nil?
 
+        raise ActiveRecord::RecordNotFound, "Mentor not found in migrated data" if period.mentor_teacher.nil?
+
         mentor_period = period.mentor_teacher.mentor_at_school_periods
           .where(school_id: teacher_period.school_id)
           .containing_period(period_dates).first

--- a/app/migration/mentorship_period_extractor.rb
+++ b/app/migration/mentorship_period_extractor.rb
@@ -1,0 +1,46 @@
+class MentorshipPeriodExtractor
+  include Enumerable
+
+  def initialize(induction_records:)
+    @induction_records = induction_records
+  end
+
+  def each(&block)
+    return to_enum(__method__) { mentorship_periods.size } unless block_given?
+
+    mentorship_periods.each(&block)
+  end
+
+private
+
+  def mentorship_periods
+    @mentorship_periods ||= build_mentorship_periods
+  end
+
+  def build_mentorship_periods
+    current_period = nil
+    current_mentor = nil
+
+    @induction_records.each_with_object([]) do |induction_record, periods|
+      mentor_id = induction_record.mentor_profile_id
+
+      next if current_mentor.nil? && mentor_id.nil?
+
+      if current_mentor != mentor_id
+        current_mentor = mentor_id
+
+        mentor_teacher = ::Teacher.find_by(legacy_mentor_id: mentor_id)
+
+        current_period = Migration::MentorshipPeriodData.new(mentor_teacher:,
+                                                             start_date: induction_record.start_date,
+                                                             end_date: induction_record.end_date,
+                                                             start_source_id: induction_record.id,
+                                                             end_source_id: induction_record.id)
+        periods << current_period
+      else
+        current_period.end_date = induction_record.end_date
+        current_period.end_source_id = induction_record.id
+      end
+    end
+  end
+end

--- a/app/migration/migrators/mentorship_period.rb
+++ b/app/migration/migrators/mentorship_period.rb
@@ -35,7 +35,7 @@ module Migrators
 
       mentorship_periods = MentorshipPeriodExtractor.new(induction_records:)
 
-      Builders::MentorshipPeriod.new(teacher:, mentorship_periods:).process!
+      Builders::MentorshipPeriods.new(teacher:, mentorship_periods:).process!
     end
   end
 end

--- a/app/migration/migrators/mentorship_period.rb
+++ b/app/migration/migrators/mentorship_period.rb
@@ -1,0 +1,35 @@
+module Migrators
+  class MentorshipPeriod < Migrators::Base
+    def self.record_count
+      ects.count
+    end
+
+    def self.model
+      :mentorship_period
+    end
+
+    def self.ects
+      ::Teacher.where.associated(:ect_at_school_periods).distinct
+    end
+
+    def self.dependencies
+      %i[teacher]
+    end
+
+    def self.reset!
+      if Rails.application.config.enable_migration_testing
+        ::MentorshipPeriod.connection.execute("TRUNCATE #{::MentorshipPeriod.table_name} RESTART IDENTITY CASCADE")
+      end
+    end
+
+    def migrate!
+      migrate(self.class.ects) do |teacher|
+        migrate_mentorships!(teacher:)
+      end
+    end
+
+    def migrate_mentorships!(teacher:)
+    end
+
+  end
+end

--- a/app/migration/migrators/mentorship_period.rb
+++ b/app/migration/migrators/mentorship_period.rb
@@ -30,12 +30,12 @@ module Migrators
 
     def migrate_mentorships!(teacher:)
       participant_profile = Migration::ParticipantProfile.find(teacher.legacy_ect_id)
-      irs = InductionRecordSanitizer.new(participant_profile:)
-      irs.validate!
+      induction_records = InductionRecordSanitizer.new(participant_profile:)
+      induction_records.validate!
 
-      mentorship_periods = MentorshipPeriodExtractor.new(induction_records:)
+      mentorship_period_data = MentorshipPeriodExtractor.new(induction_records:)
 
-      Builders::MentorshipPeriods.new(teacher:, mentorship_periods:).process!
+      Builders::MentorshipPeriods.new(teacher:, mentorship_period_data:).process!
     end
   end
 end

--- a/app/migration/migrators/mentorship_period.rb
+++ b/app/migration/migrators/mentorship_period.rb
@@ -29,7 +29,13 @@ module Migrators
     end
 
     def migrate_mentorships!(teacher:)
-    end
+      participant_profile = Migration::ParticipantProfile.find(teacher.legacy_ect_id)
+      irs = InductionRecordSanitizer.new(participant_profile:)
+      irs.validate!
 
+      mentorship_periods = MentorshipPeriodExtractor.new(induction_records:)
+
+      Builders::MentorshipPeriod.new(teacher:, mentorship_periods:).process!
+    end
   end
 end

--- a/app/models/migration/mentorship_period_data.rb
+++ b/app/models/migration/mentorship_period_data.rb
@@ -1,0 +1,14 @@
+module Migration
+  # NOTE: this is a PORO to help with collating mentorship period data when processing InductionRecords
+  class MentorshipPeriodData
+    attr_accessor :mentor_teacher, :start_date, :end_date, :start_source_id, :end_source_id
+
+    def initialize(mentor_teacher:, start_date:, end_date:, start_source_id:, end_source_id:)
+      @mentor_teacher = mentor_teacher
+      @start_date = start_date
+      @end_date = end_date
+      @start_source_id = start_source_id
+      @end_source_id = end_source_id
+    end
+  end
+end

--- a/spec/factories/migration/mentorship_period_factory.rb
+++ b/spec/factories/migration/mentorship_period_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :mentorship_period_data, class: "Migration::MentorshipPeriodData" do
+    mentor_teacher factory: :teacher
+    start_date { 2.years.ago.to_date }
+    end_date { 1.month.ago.to_date }
+    start_source_id { SecureRandom.uuid }
+    end_source_id { SecureRandom.uuid }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/migration/builders/mentorship_periods_spec.rb
+++ b/spec/migration/builders/mentorship_periods_spec.rb
@@ -1,0 +1,86 @@
+describe Builders::MentorshipPeriods do
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:started_on) { 2.years.ago.to_date }
+  let(:finished_on) { 6.months.ago.to_date }
+  let!(:ect_period) { FactoryBot.create(:ect_at_school_period, :active, teacher:, started_on:, finished_on:) }
+  let(:mentor_period_1) do
+    FactoryBot.create(:mentor_at_school_period,
+                      :active,
+                      school: ect_period.school,
+                      started_on: started_on + 1.day)
+  end
+  let(:mentor_period_2) do
+    FactoryBot.create(:mentor_at_school_period,
+                      :active,
+                      school: ect_period.school,
+                      started_on: started_on - 1.week)
+  end
+
+  let(:mentorship_period_1) do
+    FactoryBot.build(:mentorship_period_data,
+                     mentor_teacher: mentor_period_1.teacher,
+                     start_date: started_on + 2.days,
+                     end_date: started_on + 2.weeks)
+  end
+  let(:mentorship_period_2) do
+    FactoryBot.build(:mentorship_period_data,
+                     mentor_teacher: mentor_period_2.teacher,
+                     start_date: started_on + 1.month,
+                     end_date: started_on + 3.months)
+  end
+  let(:mentorship_period_data) { [mentorship_period_1, mentorship_period_2] }
+
+  subject(:service) { described_class.new(teacher:, mentorship_period_data:) }
+
+  describe "#process!" do
+    it "creates MentorshipPeriod records for the mentorship periods" do
+      expect {
+        service.process!
+      }.to change { MentorshipPeriod.count }.by(2)
+    end
+
+    it "populates the MentorshipPeriod records with the correct information" do
+      service.process!
+      periods = ect_period.mentorship_periods.order(:started_on)
+
+      expect(periods.first.mentor).to eq mentor_period_1
+      expect(periods.first.started_on).to eq mentorship_period_1.start_date
+      expect(periods.first.finished_on).to eq mentorship_period_1.end_date
+      expect(periods.first.legacy_start_id).to eq mentorship_period_1.start_source_id
+      expect(periods.first.legacy_end_id).to eq mentorship_period_1.end_source_id
+
+      expect(periods.last.mentor).to eq mentor_period_2
+      expect(periods.last.started_on).to eq mentorship_period_2.start_date
+      expect(periods.last.finished_on).to eq mentorship_period_2.end_date
+      expect(periods.last.legacy_start_id).to eq mentorship_period_2.start_source_id
+      expect(periods.last.legacy_end_id).to eq mentorship_period_2.end_source_id
+    end
+
+    context "when there is no ECTAtSchoolPeriod that contains the training dates" do
+      let!(:ect_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: started_on + 1.month, finished_on:) }
+      it "raises an error" do
+        expect {
+          service.process!
+        }.to(raise_error { ActiveRecord::RecordNotFound }.with_message("No ECTAtSchoolPeriod found for mentorship dates"))
+      end
+    end
+
+    context "when there is no MentorAtSchoolPeriod that contains the training dates" do
+      let(:mentor_period_2) { FactoryBot.create(:mentor_at_school_period, school: ect_period.school, started_on: 1.month.ago) }
+      it "raises an error" do
+        expect {
+          service.process!
+        }.to(raise_error { ActiveRecord::RecordNotFound }.with_message("No MentorAtSchoolPeriod found for mentorship dates"))
+      end
+    end
+
+    context "when the mentor does not have a MentorAtSchoolPeriod at the same school" do
+      let(:mentor_period_1) { FactoryBot.create(:mentor_at_school_period, :active, started_on: started_on + 1.day) }
+      it "raises an error" do
+        expect {
+          service.process!
+        }.to(raise_error { ActiveRecord::RecordNotFound }.with_message("No MentorAtSchoolPeriod found for mentorship dates"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add the migrator to generate `MentorshipPeriod` records from ECT's `InductionRecord` data

The migrator:
 1. iterates through the ECT's `InductionRecord`s and builds the periods of time they are with their assigned mentors
 2. iterates those periods and matches them with the respective `Teacher` records and their `ECTAtSchoolPeriod` and `MentorAtSchoolPeriod` records
 3. checks to ensure the records are contained within the mentee and mentors periods at the same school.
 4. creates the `MentorshipPeriod` record