### PR TITLE
Flush the output_buffer after parsing front matter

### DIFF
--- a/config/initializers/markdown_renderer.rb
+++ b/config/initializers/markdown_renderer.rb
@@ -1,24 +1,30 @@
 module MarkdownRenderer
   def self.call(template, source)
     erb_handler = ActionView::Template.registered_template_handler(:erb)
-    page_sections = source.match(/^\s*---(?<front_matter>.*?)---\s(?<markdown>.*)/m)
 
-    if page_sections
+    if (page_sections = source.match(/^\s*---(?<front_matter>.*?)---\s(?<markdown>.*)/m))
       front_matter = erb_handler.call(template, page_sections[:front_matter])
       page_content = erb_handler.call(template, page_sections[:markdown])
+
+      # Flush the @output_buffer between retrieving front_matter and
+      # rendering the rest of the page so we don't render the front_matter
+      # unintentionally
+      <<~RUBY
+        page_data_from_front_matter(begin; #{front_matter}; end)
+
+        @output_buffer = ActionView::OutputBuffer.new;
+
+        MarkdownRenderer.render(begin; #{page_content}; end)
+      RUBY
     else
       page_content = erb_handler.call(template, source)
-      front_matter = 'nil'
-    end
 
-    <<~RUBY
-      page_data_from_front_matter(begin; #{front_matter}; end)
-      MarkdownRenderer.render(begin; #{page_content}; end)
-    RUBY
+      "MarkdownRenderer.render(begin; #{page_content}; end)"
+    end
   end
 
   def self.render(markdown)
-    GovukMarkdown.render(markdown.to_str).html_safe
+    GovukMarkdown.render(markdown.to_str, { strip_front_matter: true }).html_safe
   end
 end
 

--- a/spec/initializers/markdown_renderer_spec.rb
+++ b/spec/initializers/markdown_renderer_spec.rb
@@ -14,12 +14,7 @@ RSpec.describe MarkdownRenderer do
       allow(erb_handler).to receive(:call).with(template, source).and_return('"processed markdown"')
 
       rendered = MarkdownRenderer.call(template, source)
-      expect(rendered).to eq(
-        <<~RUBY
-          page_data_from_front_matter(begin; nil; end)
-          MarkdownRenderer.render(begin; "processed markdown"; end)
-        RUBY
-      )
+      expect(rendered).to eq(%{MarkdownRenderer.render(begin; "processed markdown"; end)})
     end
 
     it "processes ERB in both frontmatter and content" do
@@ -44,6 +39,9 @@ RSpec.describe MarkdownRenderer do
       expect(rendered).to eq(
         <<~RUBY
           page_data_from_front_matter(begin; "processed frontmatter"; end)
+
+          @output_buffer = ActionView::OutputBuffer.new;
+
           MarkdownRenderer.render(begin; "processed content"; end)
         RUBY
       )
@@ -69,6 +67,9 @@ RSpec.describe MarkdownRenderer do
       expect(rendered).to eq(
         <<~RUBY
           page_data_from_front_matter(begin; "processed invalid frontmatter"; end)
+
+          @output_buffer = ActionView::OutputBuffer.new;
+
           MarkdownRenderer.render(begin; "processed content"; end)
         RUBY
       )
@@ -81,12 +82,7 @@ RSpec.describe MarkdownRenderer do
         .and_return('"processed content with variables"')
 
       rendered = MarkdownRenderer.call(template, source)
-      expect(rendered).to eq(
-        <<~RUBY
-          page_data_from_front_matter(begin; nil; end)
-          MarkdownRenderer.render(begin; "processed content with variables"; end)
-        RUBY
-      )
+      expect(rendered).to eq(%{MarkdownRenderer.render(begin; "processed content with variables"; end)})
     end
   end
 end


### PR DESCRIPTION
This solves a bug where our calling of erb_handler.call twice means we're writing two bits of content to the @output_buffer, even though we only need the second because front matter is used to populate page_data rather than it directly contributing to the page.

Fixes #695

| Before | After |
| ------- | ---------- |
| ![image](https://github.com/user-attachments/assets/5b213cce-d633-4653-87cc-37d8859e2562) | ![Screenshot From 2024-11-20 17-13-30](https://github.com/user-attachments/assets/53303af1-b88b-4e72-9b79-4ef403af888f) |
