### PR TITLE
Move `caption` to `page_data` so it's not rendered empty

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   include Pagy::Frontend
 
-  def page_data(title:, header: nil, header_size: "l", error: false, backlink_href: nil)
+  def page_data(title:, header: nil, header_size: "l", error: false, backlink_href: nil, caption: nil, caption_size: 'm')
     page_title = if error
                    "Error: #{title}"
                  else
@@ -20,7 +20,11 @@ module ApplicationHelper
 
     content_for(:page_header) { page_header }
 
-    { page_title:, backlink_or_breadcrumb:, page_header: }
+    page_caption = tag.span(caption, class: "govuk-caption-#{caption_size}")
+
+    content_for(:page_caption) { page_caption } unless caption.nil?
+
+    { page_title:, backlink_or_breadcrumb:, page_header:, page_caption: }
   end
 
   def page_data_from_front_matter(yaml)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
             </div>
           <% end %>
           <div class="govuk-grid-column-two-thirds">
+            <%= yield(:page_caption) %>
             <%= yield(:page_header) %>
 
             <%= yield %>

--- a/app/views/layouts/full.html.erb
+++ b/app/views/layouts/full.html.erb
@@ -22,7 +22,7 @@
 
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <h3 class="govuk-caption-xl"><%= @school_name %></h3>
+            <%= yield(:page_caption) %>
             <%= yield(:page_header) %>
           </div>
         </div>

--- a/app/views/schools/home/index.html.erb
+++ b/app/views/schools/home/index.html.erb
@@ -1,4 +1,4 @@
-<% page_data(title: "Early career teachers (ECT)", error: false) %>
+<% page_data(title: "Early career teachers (ECT)", error: false, caption: @school_name, caption_size: 'l') %>
 
 <%= govuk_button_link_to("Add an ECT", schools_register_ect_start_path) %>
 <hr class="govuk-section-break--m"/>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe ApplicationHelper, type: :helper do
     it "allows the title size to be overridden" do
       expect(page_data(title: "Some title", header: "Some header", header_size: "m").fetch(:page_header)).to eq(%(<h1 class="govuk-heading-m">Some header</h1>))
     end
+
+    it 'sets the heading caption to the provided value with the default size m' do
+      expect(page_data(title: "Some title", caption: 'Some caption').fetch(:page_caption)).to eq('<span class="govuk-caption-m">Some caption</span>')
+    end
+
+    context 'when the caption size is overridden' do
+      it 'sets the heading caption to the provided value with the provided size' do
+        expect(page_data(title: "Some title", caption: 'Some caption', caption_size: 'l').fetch(:page_caption)).to eq('<span class="govuk-caption-l">Some caption</span>')
+      end
+    end
   end
 
   describe "#page_data_from_front_matter" do


### PR DESCRIPTION
When we use the 'full' layout and `@school_name` isn't set, there's an empty `<h3>` tag at the top of the page.

We can avoid this by setting the caption using page_data and not rendering anything when the caption isn't present.
