### PR TITLE
Revert resourceful routes. dfe-wizard expects namespaces routes instead

### DIFF
--- a/app/views/schools/home/index.html.erb
+++ b/app/views/schools/home/index.html.erb
@@ -1,6 +1,6 @@
 <% page_data(title: "Early career teachers (ECT)", error: false, caption: @school_name, caption_size: 'l') %>
 
-<%= govuk_button_link_to("Add an ECT", start_schools_register_ect_path) %>
+<%= govuk_button_link_to("Add an ECT", schools_register_ect_start_path) %>
 <hr class="govuk-section-break--m"/>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">

--- a/app/views/schools/register_ect/check_answers.html.erb
+++ b/app/views/schools/register_ect/check_answers.html.erb
@@ -1,4 +1,4 @@
-<% page_data(title: "Check your answers before submitting", backlink_href: email_address_schools_register_ect_path) %>
+<% page_data(title: "Check your answers before submitting", backlink_href: schools_register_ect_email_address_path) %>
 
 <h2 class="govuk-heading-m">Teacher details</h2>
 <%= govuk_summary_list do |summary_list|

--- a/app/views/schools/register_ect/email_address.html.erb
+++ b/app/views/schools/register_ect/email_address.html.erb
@@ -1,4 +1,4 @@
-<% page_data(title: "What is #{@ect.full_name}'s email address?", error: @wizard.current_step.errors.present?, backlink_href: review_ect_details_schools_register_ect_path) %>
+<% page_data(title: "What is #{@ect.full_name}'s email address?", error: @wizard.current_step.errors.present?, backlink_href: schools_register_ect_review_ect_details_path) %>
 
 <p class="govuk-body">You must provide an email address that your ECT can access. You can update it later if needed.</p>
 

--- a/app/views/schools/register_ect/find_ect.html.erb
+++ b/app/views/schools/register_ect/find_ect.html.erb
@@ -1,4 +1,4 @@
-<% page_data(title: "Find an ECT", error: @wizard.current_step.errors.present?, backlink_href: start_schools_register_ect_path) %>
+<% page_data(title: "Find an ECT", error: @wizard.current_step.errors.present?, backlink_href: schools_register_ect_start_path) %>
 
 <p class="govuk-body">Enter your ECT's teacher reference number and date of birth to find them.</p>
 

--- a/app/views/schools/register_ect/national_insurance_number.html.erb
+++ b/app/views/schools/register_ect/national_insurance_number.html.erb
@@ -1,4 +1,4 @@
-<% page_data(title: "We cannot find your ECT's details", backlink_href: find_ect_schools_register_ect_path) %>
+<% page_data(title: "We cannot find your ECT's details", backlink_href: schools_register_ect_find_ect_path) %>
 
 <p class="govuk-body">We cannot find a match with the details you've given. You'll need to provide more information about your ECT to help us locate them.</p>
 

--- a/app/views/schools/register_ect/not_found.html.erb
+++ b/app/views/schools/register_ect/not_found.html.erb
@@ -4,4 +4,4 @@
 <p class="govuk-body">You can check the ECT's teacher reference number (TRN) is accurate by <%= govuk_link_to('reviewing their teacher record', 'https://check-a-teachers-record.education.gov.uk/check-records/sign-in') %>.</p>
 <p class="govuk-body">Alternatively, you can ask the ECT to check their TRN by using the <%= govuk_link_to('Find a lost TRN service', 'https://find-a-lost-trn.education.gov.uk/start') %>.</p>
 
-<%= govuk_button_link_to("Try again", find_ect_schools_register_ect_path) %>
+<%= govuk_button_link_to("Try again", schools_register_ect_find_ect_path) %>

--- a/app/views/schools/register_ect/review_ect_details.html.erb
+++ b/app/views/schools/register_ect/review_ect_details.html.erb
@@ -1,4 +1,4 @@
-<% page_data(title: "Check if this is your ECT", backlink_href: find_ect_schools_register_ect_path) %>
+<% page_data(title: "Check if this is your ECT", backlink_href: schools_register_ect_find_ect_path) %>
 
 <%= govuk_summary_list do |summary_list|
   summary_list.with_row do |row|
@@ -30,5 +30,5 @@ end %>
 
 <div class="govuk-inset-text">
   If this is not the person you intended to register as an ECT, go back
-  and <%= govuk_link_to("check details", find_ect_schools_register_ect_path) %>.
+  and <%= govuk_link_to("check details", schools_register_ect_find_ect_path) %>.
 </div>

--- a/app/views/schools/register_ect/start.html.erb
+++ b/app/views/schools/register_ect/start.html.erb
@@ -21,4 +21,4 @@
 <p class="govuk-body">If you have not assigned a mentor for your ECT, you can still register them by providing the
   mentor's details later.</p>
 
-<%= govuk_button_link_to("Continue", find_ect_schools_register_ect_path) %>
+<%= govuk_button_link_to("Continue", schools_register_ect_find_ect_path) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,22 +88,27 @@ Rails.application.routes.draw do
   namespace :schools do
     get "/home/ects", to: "home#index", as: :ects_home
 
-    resource :register_ect, path: "register-ect", only: %i[] do
-      collection do
-        get "what-you-will-need", action: :start, as: :start
-        get "find-ect", action: :new
-        post "find-ect", action: :create
-        get "national-insurance-number", action: :new
-        post "national-insurance-number", action: :create
-        get "not-found", action: :new
-        get "review-ect-details", action: :new
-        post "review-ect-details", action: :create
-        get "email-address", action: :new
-        post "email-address", action: :create
-        get "check-answers", action: :new
-        post "check-answers", action: :create
-        get "confirmation", action: :new
-      end
+    namespace :register_ect, path: "register-ect" do
+      get "what-you-will-need", as: :start, action: :start
+
+      get "find-ect", action: :new
+      post "find-ect", action: :create
+
+      get "national-insurance-number", action: :new
+      post "national-insurance-number", action: :create
+
+      get "not-found", action: :new
+
+      get "review-ect-details", action: :new
+      post "review-ect-details", action: :create
+
+      get "email-address", action: :new
+      post "email-address", action: :create
+
+      get "check-answers", action: :new
+      post "check-answers", action: :create
+
+      get "confirmation", action: :new
     end
   end
 end


### PR DESCRIPTION
Dfe-Wizard expects step routes with the pattern `namespece_step_name_path` which is not compatible with resourceful routes that would make Rails create routes with the pattern `step_name_namespace_path` instead. 

This PR redefines the step routes of the register-ect journey using a namespace `register-ect` instead of a resource.