### PR TITLE
Pass the appropriate body record into `#sign_in_as`

### DIFF
--- a/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT' do
   include AuthHelper
-  let(:appropriate_body) { AppropriateBody.find(session[:appropriate_body_id]) }
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:page_heading) { "Check details for" }
   let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
   let(:pending_induction_submission_id_param) { pending_induction_submission.id.to_s }
@@ -16,9 +16,7 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
     end
 
     context 'when signed in as an appropriate body user' do
-      # FIXME: we don't have appropriate body users yet so this is just making
-      #        sure they're logged in
-      let!(:user) { sign_in_as(:appropriate_body_user) }
+      let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
 
       it 'finds the right PendingInductionSubmission record and renders the page' do
         allow(PendingInductionSubmission).to receive(:find).with(pending_induction_submission_id_param).and_call_original
@@ -42,7 +40,7 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
     end
 
     context 'when signed in' do
-      let!(:user) { sign_in_as(:appropriate_body_user) }
+      let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
       before { allow(AppropriateBodies::ClaimAnECT::CheckECT).to receive(:new).with(any_args).and_call_original }
 
       context "when the submission is valid" do

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
   include_context 'fake trs api client'
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 
   let(:page_heading) { "Find an early career teacher" }
 
@@ -14,9 +15,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
     end
 
     context 'when signed in as an appropriate body user' do
-      # FIXME: we don't have appropriate body users yet so this is just making
-      #        sure they're logged in
-      let!(:user) { sign_in_as(:appropriate_body_user) }
+      let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
 
       it 'instantiates a new PendingInductionSubmission and renders the page' do
         allow(PendingInductionSubmission).to receive(:new).and_call_original
@@ -43,8 +42,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
     context 'when signed in' do
       before { allow(AppropriateBodies::ClaimAnECT::FindECT).to receive(:new).with(any_args).and_call_original }
 
-      let!(:user) { sign_in_as(:appropriate_body_user) }
-      let(:appropriate_body) { AppropriateBody.find(session[:appropriate_body_id]) }
+      let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
       let(:birth_year_param) { "2001" }
       let(:trn) { "1234567" }
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
-  let(:appropriate_body) { AppropriateBody.find(session[:appropriate_body_id]) }
-  let(:page_heading) { "Tell us about" }
+  let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+  let(:page_heading) { "Tell us about" }
   let(:pending_induction_submission_id_param) { pending_induction_submission.id.to_s }
 
   describe 'GET /appropriate-body/claim-an-ect/register-ect/:id/edit' do
@@ -17,7 +17,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
     context 'when signed in as an appropriate body user' do
       # FIXME: we don't have appropriate body users yet so this is just making
       #        sure they're logged in
-      before { sign_in_as(:appropriate_body_user) }
+      before { sign_in_as(:appropriate_body_user, appropriate_body:) }
 
       it 'finds the right PendingInductionSubmission record and renders the page' do
         allow(PendingInductionSubmission).to receive(:find).with(pending_induction_submission_id_param).and_call_original
@@ -41,7 +41,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
     end
 
     context 'when signed in' do
-      let!(:user) { sign_in_as(:appropriate_body_user) }
+      let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
       before { allow(AppropriateBodies::ClaimAnECT::CheckECT).to receive(:new).with(any_args).and_call_original }
       before { allow(AppropriateBodies::ClaimAnECT::RegisterECT).to receive(:new).with(any_args).and_call_original }
 
@@ -115,7 +115,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
     end
 
     context 'when signed in' do
-      before { sign_in_as(:appropriate_body_user) }
+      before { sign_in_as(:appropriate_body_user, appropriate_body:) }
 
       it 'finds the right PendingInductionSubmission record and renders the page' do
         allow(PendingInductionSubmission).to receive(:find).with(pending_induction_submission_id_param).and_call_original

--- a/spec/requests/appropriate_bodies/teachers/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/index_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Appropriate Body teacher index page", type: :request do
   include AuthHelper
-  let(:appropriate_body) { user.appropriate_bodies.first }
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 
   describe 'GET /appropriate-body/teachers' do
     context 'when not signed in' do
@@ -15,7 +15,7 @@ RSpec.describe "Appropriate Body teacher index page", type: :request do
     end
 
     context 'when signed in as an appropriate body user' do
-      let!(:user) { sign_in_as(:appropriate_body_user) }
+      let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
       let!(:emma) { FactoryBot.create(:teacher, first_name: 'Emma') }
       let!(:john) { FactoryBot.create(:teacher, first_name: 'John') }
 

--- a/spec/support/requests/auth_helper.rb
+++ b/spec/support/requests/auth_helper.rb
@@ -1,10 +1,10 @@
 module AuthHelper
-  def sign_in_as(user_type, method: :persona)
+  def sign_in_as(user_type, method: :persona, appropriate_body: nil)
     Rails.logger.info("logging in as #{user_type}")
 
     case method
     when :otp then sign_in_with_otp(user_type)
-    when :persona then sign_in_with_persona(user_type)
+    when :persona then sign_in_with_persona(user_type, appropriate_body:)
     end
   end
 
@@ -22,13 +22,14 @@ private
     end
   end
 
-  def sign_in_with_persona(user_type)
+  def sign_in_with_persona(user_type, appropriate_body:)
     FactoryBot.create(:user, user_type).tap do |user|
       case user_type
       when :appropriate_body_user
+        fail(ArgumentError, "appropriate_body missing") unless appropriate_body
+
         Rails.logger.debug("Signing in with persona as appropriate body user")
         post("/auth/developer/callback", params: { email: user.email, name: user.name })
-        appropriate_body = FactoryBot.create(:appropriate_body)
         put("/personas/appropriate-body-sessions", params: { appropriate_body_id: appropriate_body.id })
       end
     end


### PR DESCRIPTION
This change adjusts the behaviour of the `#sign_in_as` helper method used in specs so that the appropriate body the user will be signed in with is provided rather than generated. It makes finding the correct AB in the database much more predictable.
