### PR TITLE
Make OmniAuth use Rails logger

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,4 +3,6 @@ Rails.application.config.middleware.use(OmniAuth::Builder) do
   provider(:developer,
            fields: %i[name email],
            uid_field: :email)
+
+  OmniAuth.config.logger = Rails.logger
 end


### PR DESCRIPTION
This prevents the test output from being interrupted by OmniAuth informing us that 'Callback phase initiated'.
