### PR TITLE
End ‘register ECT’ journey if teacher is exempt from induction

### DIFF
--- a/app/components/test_guidance_component.rb
+++ b/app/components/test_guidance_component.rb
@@ -14,6 +14,7 @@ class TestGuidanceComponent < ViewComponent::Base
     def rows
       [
         ["1000890", "15/01/1997", "JL049125A", "Induction completed"],
+        ["3002564", "05/07/1991", "JK028223B", "Exempt from induction"],
         ["3002586", "03/02/1977", "OA647867D", ""],
         ["3002585", "02/01/1966", "MA251209B", ""],
         ["3002584", "24/11/1955", "RE937588C", ""],

--- a/app/views/schools/register_ect/induction_completed.html.erb
+++ b/app/views/schools/register_ect/induction_completed.html.erb
@@ -1,5 +1,5 @@
 <% page_data(title: "You cannot register #{@ect.full_name}", error: false) %>
 
-<p class="govuk-body">Our records show <%= @ect.full_name %> has already completed their induction and is not eligible for further ECT training.</p>
+<p class="govuk-body">Our records show <%= @ect.full_name %> has already completed their induction and therefore cannot be registered as an ECT.</p>
 
 <p class="govuk-body"><%= govuk_link_to("Register another ECT", schools_register_ect_find_ect_path) %></p>

--- a/app/views/schools/register_ect/induction_exempt.html.erb
+++ b/app/views/schools/register_ect/induction_exempt.html.erb
@@ -1,5 +1,5 @@
 <% page_data(title: "You cannot register #{@ect.full_name}", error: false) %>
 
-<p class="govuk-body">Our records show <%= @ect.full_name %> is exempt from having to serve induction so you cannot register them for ECF training.</p>
+<p class="govuk-body">Our records show <%= @ect.full_name %> is exempt from having to serve induction and therefore cannot be registered as an ECT.</p>
 
 <p class="govuk-body"><%= govuk_link_to("Register another ECT", schools_register_ect_find_ect_path) %></p>

--- a/app/views/schools/register_ect/induction_exempt.html.erb
+++ b/app/views/schools/register_ect/induction_exempt.html.erb
@@ -1,0 +1,5 @@
+<% page_data(title: "You cannot register #{@ect.full_name}", error: false) %>
+
+<p class="govuk-body">Our records show <%= @ect.full_name %> is exempt from having to serve induction so you cannot register them for ECF training.</p>
+
+<p class="govuk-body"><%= govuk_link_to("Register another ECT", schools_register_ect_find_ect_path) %></p>

--- a/app/wizards/schools/register_ect/ect.rb
+++ b/app/wizards/schools/register_ect/ect.rb
@@ -19,12 +19,6 @@ module Schools
         trs_date_of_birth.to_date == date_of_birth.to_date
       end
 
-      def matches_trs_national_insurance_number?
-        return false if [national_insurance_number, trs_national_insurance_number].any?(&:blank?)
-
-        trs_national_insurance_number == national_insurance_number
-      end
-
       def induction_completed?
         trs_induction_status == 'Pass'
       end

--- a/app/wizards/schools/register_ect/ect.rb
+++ b/app/wizards/schools/register_ect/ect.rb
@@ -26,11 +26,11 @@ module Schools
       end
 
       def induction_completed?
-        trs_induction_completed?
+        trs_induction_status == 'Pass'
       end
 
       def induction_exempt?
-        trs_induction_exempt?
+        trs_induction_status == 'Exempt'
       end
     end
   end

--- a/app/wizards/schools/register_ect/ect.rb
+++ b/app/wizards/schools/register_ect/ect.rb
@@ -28,6 +28,10 @@ module Schools
       def induction_completed?
         trs_induction_completed?
       end
+
+      def induction_exempt?
+        trs_induction_exempt?
+      end
     end
   end
 end

--- a/app/wizards/schools/register_ect/find_ect_step.rb
+++ b/app/wizards/schools/register_ect/find_ect_step.rb
@@ -31,8 +31,7 @@ module Schools
                    trs_trn: trs_teacher.trn,
                    trs_first_name: trs_teacher.first_name,
                    trs_last_name: trs_teacher.last_name,
-                   trs_induction_completed?: trs_teacher.induction_status == 'Pass',
-                   trs_induction_exempt?: trs_teacher.induction_status == 'Exempt')
+                   trs_induction_status: trs_teacher.induction_status)
       end
 
       def trs_teacher

--- a/app/wizards/schools/register_ect/find_ect_step.rb
+++ b/app/wizards/schools/register_ect/find_ect_step.rb
@@ -14,9 +14,9 @@ module Schools
 
       def next_step
         return :trn_not_found unless ect.in_trs?
-        return :induction_completed if ect.induction_completed? && ect.matches_trs_dob?
-        return :induction_exempt if ect.induction_exempt? && ect.matches_trs_dob?
         return :national_insurance_number unless ect.matches_trs_dob?
+        return :induction_completed if ect.induction_completed?
+        return :induction_exempt if ect.induction_exempt?
 
         :review_ect_details
       end

--- a/app/wizards/schools/register_ect/find_ect_step.rb
+++ b/app/wizards/schools/register_ect/find_ect_step.rb
@@ -15,6 +15,7 @@ module Schools
       def next_step
         return :trn_not_found unless ect.in_trs?
         return :induction_completed if ect.induction_completed? && ect.matches_trs_dob?
+        return :induction_exempt if ect.induction_exempt? && ect.matches_trs_dob?
         return :national_insurance_number unless ect.matches_trs_dob?
 
         :review_ect_details
@@ -30,7 +31,8 @@ module Schools
                    trs_trn: trs_teacher.trn,
                    trs_first_name: trs_teacher.first_name,
                    trs_last_name: trs_teacher.last_name,
-                   trs_induction_completed?: trs_teacher.induction_status == 'Pass')
+                   trs_induction_completed?: trs_teacher.induction_status == 'Pass',
+                   trs_induction_exempt?: trs_teacher.induction_status == 'Exempt')
       end
 
       def trs_teacher

--- a/app/wizards/schools/register_ect/find_ect_step.rb
+++ b/app/wizards/schools/register_ect/find_ect_step.rb
@@ -26,7 +26,6 @@ module Schools
       def persist
         ect.update(trn:,
                    date_of_birth: date_of_birth.values.join("-"),
-                   trs_national_insurance_number: trs_teacher.national_insurance_number,
                    trs_date_of_birth: trs_teacher.date_of_birth,
                    trs_trn: trs_teacher.trn,
                    trs_first_name: trs_teacher.first_name,

--- a/app/wizards/schools/register_ect/induction_exempt_step.rb
+++ b/app/wizards/schools/register_ect/induction_exempt_step.rb
@@ -1,0 +1,6 @@
+module Schools
+  module RegisterECT
+    class InductionExemptStep < Step
+    end
+  end
+end

--- a/app/wizards/schools/register_ect/national_insurance_number_step.rb
+++ b/app/wizards/schools/register_ect/national_insurance_number_step.rb
@@ -27,8 +27,7 @@ module Schools
                    trs_date_of_birth: trs_teacher.date_of_birth,
                    trs_first_name: trs_teacher.first_name,
                    trs_last_name: trs_teacher.last_name,
-                   trs_induction_completed?: trs_teacher.induction_status == 'Pass',
-                   trs_induction_exempt?: trs_teacher.induction_status == 'Exempt')
+                   trs_induction_status: trs_teacher.induction_status)
       end
 
       def trs_teacher

--- a/app/wizards/schools/register_ect/national_insurance_number_step.rb
+++ b/app/wizards/schools/register_ect/national_insurance_number_step.rb
@@ -14,6 +14,7 @@ module Schools
       def next_step
         return :not_found unless ect.in_trs?
         return :induction_completed if ect.induction_completed? && ect.matches_trs_national_insurance_number?
+        return :induction_exempt if ect.induction_exempt? && ect.matches_trs_national_insurance_number?
 
         :review_ect_details
       end
@@ -26,7 +27,8 @@ module Schools
                    trs_date_of_birth: trs_teacher.date_of_birth,
                    trs_first_name: trs_teacher.first_name,
                    trs_last_name: trs_teacher.last_name,
-                   trs_induction_completed?: trs_teacher.induction_status == 'Pass')
+                   trs_induction_completed?: trs_teacher.induction_status == 'Pass',
+                   trs_induction_exempt?: trs_teacher.induction_status == 'Exempt')
       end
 
       def trs_teacher

--- a/app/wizards/schools/register_ect/national_insurance_number_step.rb
+++ b/app/wizards/schools/register_ect/national_insurance_number_step.rb
@@ -13,8 +13,8 @@ module Schools
 
       def next_step
         return :not_found unless ect.in_trs?
-        return :induction_completed if ect.induction_completed? && ect.matches_trs_national_insurance_number?
-        return :induction_exempt if ect.induction_exempt? && ect.matches_trs_national_insurance_number?
+        return :induction_completed if ect.induction_completed?
+        return :induction_exempt if ect.induction_exempt?
 
         :review_ect_details
       end
@@ -23,7 +23,6 @@ module Schools
 
       def persist
         ect.update(national_insurance_number:,
-                   trs_national_insurance_number: trs_teacher.national_insurance_number,
                    trs_date_of_birth: trs_teacher.date_of_birth,
                    trs_first_name: trs_teacher.first_name,
                    trs_last_name: trs_teacher.last_name,

--- a/app/wizards/schools/register_ect/wizard.rb
+++ b/app/wizards/schools/register_ect/wizard.rb
@@ -13,6 +13,7 @@ module Schools
             email_address: EmailAddressStep,
             find_ect: FindECTStep,
             induction_completed: InductionCompletedStep,
+            induction_exempt: InductionExemptStep,
             national_insurance_number: NationalInsuranceNumberStep,
             not_found: NotFoundStep,
             review_ect_details: ReviewECTDetailsStep,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,8 @@ Rails.application.routes.draw do
 
       get "induction-completed", action: :new
 
+      get "induction-exempt", action: :new
+
       get "review-ect-details", action: :new
       post "review-ect-details", action: :create
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,11 +99,9 @@ Rails.application.routes.draw do
       post "national-insurance-number", action: :create
 
       get "trn-not-found", action: :new
-
       get "not-found", action: :new
 
       get "induction-completed", action: :new
-
       get "induction-exempt", action: :new
 
       get "review-ect-details", action: :new

--- a/spec/features/schools/register_an_ect/edge_cases/induction_exempt/find_ect_step_spec.rb
+++ b/spec/features/schools/register_an_ect/edge_cases/induction_exempt/find_ect_step_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe 'Registering an ECT' do
+  include_context 'fake trs api client that finds teacher that is exempt from induction'
+
+  let(:page) { RSpec.configuration.playwright_page }
+
+  before do
+    sign_in_as_admin
+  end
+
+  scenario 'User enters date of birth (find ECT step) but teacher has completed their induction' do
+    given_i_am_on_the_find_ect_step_page
+    and_i_submit_a_date_of_birth_and_trn_of_a_teacher_that_has_completed_their_induction
+    then_i_should_be_taken_to_the_teacher_has_completed_their_induction_error_page
+
+    when_i_click_register_another_ect
+    then_i_should_be_taken_to_the_find_ect_step_page
+  end
+
+  def given_i_am_on_the_find_ect_step_page
+    path = '/schools/register-ect/find-ect'
+    page.goto path
+    expect(page.url).to end_with(path)
+  end
+
+  def and_i_submit_a_date_of_birth_and_trn_of_a_teacher_that_has_completed_their_induction
+    page.get_by_label('trn').fill('9876543')
+    page.get_by_label('day').fill('1')
+    page.get_by_label('month').fill('12')
+    page.get_by_label('year').fill('2000')
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_teacher_has_completed_their_induction_error_page
+    path = '/schools/register-ect/induction-exempt'
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_click_register_another_ect
+    page.get_by_role('link', name: 'Register another ECT').click
+  end
+
+  def then_i_should_be_taken_to_the_find_ect_step_page
+    path = '/schools/register-ect/find-ect'
+    expect(page.url).to end_with(path)
+  end
+end

--- a/spec/features/schools/register_an_ect/edge_cases/induction_exempt/national_insurance_number_step_spec.rb
+++ b/spec/features/schools/register_an_ect/edge_cases/induction_exempt/national_insurance_number_step_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe 'Registering an ECT' do
+  include_context 'fake trs api returns a teacher and then a teacher that is exempt from induction'
+
+  let(:page) { RSpec.configuration.playwright_page }
+
+  before do
+    sign_in_as_admin
+  end
+
+  scenario 'User enters national insurance number but teacher is exempt from induction' do
+    given_i_am_on_the_find_ect_step_page
+
+    and_i_submit_a_date_of_birth_that_does_not_match
+    then_i_should_be_taken_to_the_national_insurance_number_step
+
+    when_i_enter_a_matching_national_insurance_number_but_the_teacher_has_completed_their_induction
+    then_i_should_be_taken_to_the_teacher_has_completed_their_induction_error_page
+
+    when_i_click_register_another_ect
+    then_i_should_be_taken_to_the_find_ect_step_page
+  end
+
+  def given_i_am_on_the_find_ect_step_page
+    path = '/schools/register-ect/find-ect'
+    page.goto path
+    expect(page.url).to end_with(path)
+  end
+
+  def and_i_submit_a_date_of_birth_that_does_not_match
+    page.get_by_label('trn').fill('9876543')
+    page.get_by_label('day').fill('1')
+    page.get_by_label('month').fill('2')
+    page.get_by_label('year').fill('1980')
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_teacher_has_completed_their_induction_error_page
+    path = '/schools/register-ect/induction-exempt'
+    expect(page.url).to end_with(path)
+  end
+
+  def then_i_should_be_taken_to_the_national_insurance_number_step
+    expect(page.url).to end_with('/schools/register-ect/national-insurance-number')
+  end
+
+  def when_i_enter_a_matching_national_insurance_number_but_the_teacher_has_completed_their_induction
+    page.get_by_label("National Insurance Number").fill("OA647867D")
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def when_i_click_register_another_ect
+    page.get_by_role('link', name: 'Register another ECT').click
+  end
+
+  def then_i_should_be_taken_to_the_find_ect_step_page
+    path = '/schools/register-ect/find-ect'
+    expect(page.url).to end_with(path)
+  end
+end

--- a/spec/support/shared_contexts/fake_trs_api_client.rb
+++ b/spec/support/shared_contexts/fake_trs_api_client.rb
@@ -43,11 +43,26 @@ shared_context 'fake trs api client that finds teacher that has passed their ind
   end
 end
 
+shared_context 'fake trs api client that finds teacher that is exempt from induction' do
+  before do
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(induction_status: 'Exempt'))
+  end
+end
+
 shared_context 'fake trs api returns a teacher and then a teacher that has completed their induction' do
   before do
     allow(TRS::APIClient).to receive(:new).and_return(
       TRS::FakeAPIClient.new,
       TRS::FakeAPIClient.new(induction_status: 'Pass')
+    )
+  end
+end
+
+shared_context 'fake trs api returns a teacher and then a teacher that is exempt from induction' do
+  before do
+    allow(TRS::APIClient).to receive(:new).and_return(
+      TRS::FakeAPIClient.new,
+      TRS::FakeAPIClient.new(induction_status: 'Exempt')
     )
   end
 end


### PR DESCRIPTION
### Ticket
#688 

### Changes
- Add test data for 'exempt' teacher in TestGuidance component
- If a teacher is exempt from induction, the user is redirected to a new error page

### Video 

https://github.com/user-attachments/assets/928506d7-8d96-4f66-a807-b037f2b3ab8a

