### PR TITLE
Fix release flow confirmation page

### DIFF
--- a/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
@@ -18,7 +18,10 @@ module AppropriateBodies
 
         PendingInductionSubmission.transaction do
           if @pending_induction_submission.save(context: :release_ect) && release_ect.release!
-            redirect_to ab_teacher_release_ect_path(@teacher)
+            redirect_to(
+              ab_teacher_release_ect_path(@teacher),
+              flash: { teacher_name: ::Teachers::Name.new(@teacher).full_name }
+            )
           else
             render :new
           end
@@ -26,7 +29,7 @@ module AppropriateBodies
       end
 
       def show
-        @teacher = find_teacher
+        @teacher_name = flash['teacher_name']
       end
 
     private

--- a/app/views/appropriate_bodies/teachers/release_ect/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/release_ect/show.html.erb
@@ -1,10 +1,10 @@
 <% page_data(
-  title: "#{Teachers::Name.new(@teacher).full_name} has been released",
+  title: "#{@teacher_name} has been released",
   header: false)
 %>
 
 <%=
-  govuk_panel(title_text: "Success", text: "#{Teachers::Name.new(@teacher).full_name} has been released")
+  govuk_panel(title_text: "Success", text: "#{@teacher_name} has been released")
 %>
 
 <%= govuk_button_link_to("Return to the homepage", ab_teachers_path, secondary: true) %>

--- a/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
@@ -65,7 +65,7 @@ private
 
   def then_i_should_be_on_the_success_page
     expect(page.url).to end_with("/appropriate-body/teachers/#{trn}/record-failed-outcome")
-    expect(page.locator('.govuk-panel')).to be_present
+    expect(page.locator('.govuk-panel')).to be_visible
   end
 
   def and_the_pending_induction_submission_record_should_have_the_right_data_in_it

--- a/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
@@ -65,7 +65,7 @@ private
 
   def then_i_should_be_on_the_success_page
     expect(page.url).to end_with("/appropriate-body/teachers/#{trn}/record-passed-outcome")
-    expect(page.locator('.govuk-panel')).to be_present
+    expect(page.locator('.govuk-panel')).to be_visible
   end
 
   def and_the_pending_induction_submission_record_should_have_the_right_data_in_it

--- a/spec/features/appropriate_bodies/release_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/release_an_ect_spec.rb
@@ -76,6 +76,10 @@ private
   def then_i_should_be_on_the_success_page
     expect(page.url).to end_with("/appropriate-body/teachers/#{trn}/release")
     expect(page.locator('.govuk-panel')).to be_visible
+
+    teacher_name = ::Teachers::Name.new(teacher).full_name
+
+    expect(page.locator('.govuk-panel')).to have_text(/#{teacher_name} has been released/)
   end
 
   def and_the_pending_induction_submission_should_have_been_deleted

--- a/spec/features/appropriate_bodies/release_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/release_an_ect_spec.rb
@@ -50,7 +50,7 @@ private
   end
 
   def then_i_should_see_an_error_summary
-    expect(page.locator('.govuk-error-summary')).to be_present
+    expect(page.locator('.govuk-error-summary')).to be_visible
   end
 
   def and_the_page_title_should_start_with_error
@@ -75,7 +75,7 @@ private
 
   def then_i_should_be_on_the_success_page
     expect(page.url).to end_with("/appropriate-body/teachers/#{trn}/release")
-    expect(page.locator('.govuk-panel')).to be_present
+    expect(page.locator('.govuk-panel')).to be_visible
   end
 
   def and_the_pending_induction_submission_should_have_been_deleted

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,14 @@
 require "capybara/rspec"
 require "view_component/test_helpers"
 require "view_component/system_test_helpers"
+require 'playwright'
+require 'playwright/test'
 
 RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include ViewComponent::SystemTestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+  config.include Playwright::Test::Matchers, type: :feature
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
@roseAsaf spotted a bug where the final page of the release flow showed an error.

This happened because:

1. now appropriate bodies can only see _their_ ECTs (i.e., ECTs who have an ongoing induction period with them)
2. the tests didn't catch it because the assertion was wrong - it checked `expect(page.locator('.govuk-panel')).to be_present` which will **always return true**

These are fixed, I suggest reviewing commit by commit.

## Changes

- **Replace page.locator be_present assertions with be_visible**
- **Enable Playwright::Test::Matchers for features**
- **Send the teacher name to success page via flash**
