### PR TITLE
AB UI improvements part two

### DIFF
--- a/app/controllers/appropriate_bodies/teachers/initial_teacher_training_records_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/initial_teacher_training_records_controller.rb
@@ -1,0 +1,83 @@
+module AppropriateBodies
+  module Teachers
+    class InitialTeacherTrainingRecordsController < AppropriateBodiesController
+      # [
+      #   {
+      #   "provider": {
+      #     "name": "string",
+      #     "ukprn": "string"
+      #   },
+      #   "qualification": {
+      #     "name": "string"
+      #   },
+      #   "startDate": {
+      #     "hasValue": true,
+      #     "value": "2024-11-29"
+      #   },
+      #   "endDate": {
+      #     "hasValue": true,
+      #     "value": "2024-11-29"
+      #   },
+      #   "programmeType": {
+      #     "hasValue": true,
+      #     "value": "Apprenticeship"
+      #   },
+      #   "programmeTypeDescription": "string",
+      #   "result": {
+      #     "hasValue": true,
+      #     "value": "Pass"
+      #   },
+      #   "ageRange": {
+      #     "description": "string"
+      #   },
+      #   "subjects": [
+      #     {
+      #       "code": "string",
+      #       "name": "string"
+      #     }
+      #   ]
+      # ]
+      ITTData = Struct.new(
+        :provider_name,
+        :provider_ukprn,
+        :qualification,
+        :start_date,
+        :end_date,
+        :programme_type,
+        :programme_type_description,
+        :age_range,
+        :subjects,
+        keyword_init: true
+      )
+
+      def index
+        @teacher = find_teacher
+
+        @itt_data = [
+          ITTData.new(
+            provider_name: "Education Development Trust",
+            programme_type: "Future Teaching Scholars",
+            start_date: 3.years.ago.to_date + 13.days,
+            end_date: 1.year.ago.to_date - 40.days,
+            subjects: %w[Maths English],
+            age_range: "5-11"
+          ),
+          # ITTData.new(
+          #   provider_name: "Some provider",
+          #   programme_type: "Teach First Programme",
+          #   start_date: 24.weeks.ago.to_date,
+          #   end_date: 47.days.ago.to_date,
+          #   subjects: %w[Science],
+          #   age_range: "12-18"
+          # )
+        ]
+      end
+
+    private
+
+      def find_teacher
+        AppropriateBodies::CurrentTeachers.new(@appropriate_body).current.find_by!(trn: params[:teacher_trn])
+      end
+    end
+  end
+end

--- a/app/controllers/appropriate_bodies/teachers_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers_controller.rb
@@ -8,6 +8,9 @@ module AppropriateBodies
 
     def show
       @teacher = AppropriateBodies::CurrentTeachers.new(@appropriate_body).current.find_by!(trn: params[:trn])
+
+      @current_induction_period = @teacher.induction_periods.find_by!(finished_on: nil)
+      @past_induction_periods = @teacher.induction_periods.where.not(finished_on: nil)
     end
   end
 end

--- a/app/views/appropriate_bodies/teachers/initial_teacher_training_records/index.html.erb
+++ b/app/views/appropriate_bodies/teachers/initial_teacher_training_records/index.html.erb
@@ -1,0 +1,38 @@
+<%
+  page_data(
+    title: "Initial teacher training records",
+    caption: Teachers::Name.new(@teacher).full_name,
+    backlink_href: ab_teacher_path(@teacher)
+  )
+%>
+
+<% @itt_data.each do |itt_record| %>
+  <%=
+    govuk_summary_list(card: { title: itt_record.programme_type }) do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key(text: "Provider")
+        row.with_value(text: itt_record.provider_name)
+      end
+
+      summary_list.with_row do |row|
+        row.with_key(text: "Subjects")
+        row.with_value(text: itt_record.subjects.to_sentence)
+      end
+
+      summary_list.with_row do |row|
+        row.with_key(text: "Age range")
+        row.with_value(text: itt_record.age_range)
+      end
+
+      summary_list.with_row do |row|
+        row.with_key(text: "Start date")
+        row.with_value(text: itt_record.start_date.to_fs(:govuk))
+      end
+
+      summary_list.with_row do |row|
+        row.with_key(text: "End date")
+        row.with_value(text: itt_record.end_date.to_fs(:govuk))
+      end
+    end
+  %>
+<% end %>

--- a/app/views/appropriate_bodies/teachers/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/show.html.erb
@@ -9,9 +9,8 @@
 %>
 
 <div class="govuk-button-group">
-  <%= govuk_button_link_to("Release ECT", new_ab_teacher_release_ect_path(@teacher), secondary: true) %>
-  <%= govuk_button_link_to("Record passed outcome", new_ab_teacher_record_passed_outcome_path(@teacher), secondary: true) %>
-  <%= govuk_button_link_to("Record failed outcome", new_ab_teacher_record_failed_outcome_path(@teacher), secondary: true) %>
+  <%= govuk_button_link_to("Pass induction", new_ab_teacher_record_passed_outcome_path(@teacher)) %>
+  <%= govuk_link_to("Fail induction", new_ab_teacher_record_failed_outcome_path(@teacher)) %>
 </div>
 
 <% if @teacher.induction_periods.any? %>
@@ -22,8 +21,17 @@
         <%= govuk_visually_hidden('Induction') %> Start date
       <% end %>
 
-      <% row.with_value(text: @teacher.induction_periods.last.started_on.to_fs(:govuk)) %>
+      <% row.with_value(text: @teacher.induction_periods.first.started_on.to_fs(:govuk)) %>
     <% end %>
+
+    <% sl.with_row do |row| %>
+      <% row.with_key do %>
+        <%= govuk_visually_hidden('Induction') %> Status
+      <% end %>
+
+      <% row.with_value(text: govuk_tag(text: "placeholder", colour: %w[grey green red purple orange yellow].sample)) %>
+    <% end %>
+
 
     <% sl.with_row do |row| %>
       <% if @teacher.induction_extensions.any? %>
@@ -35,8 +43,8 @@
           <%= Teachers::InductionExtensions.new(@teacher).formatted_number_of_terms %>
         <% end %>
 
-        <%= row.with_action(text: "View", visually_hidden_text: "extensions", href: ab_teacher_extensions_path(@teacher)) %>
-        <%= row.with_action(text: "Add", visually_hidden_text: "an extension", href: "#") %>
+        <%= row.with_action(text: "View", visually_hidden_text: "extensions", href: ab_teacher_extensions_path(@teacher), classes: 'govuk-link--no-visited-state') %>
+        <%# row.with_action(text: "Add", visually_hidden_text: "an extension", href: "#", classes: 'govuk-link--no-visited-state') %>
       <% else %>
         <% row.with_key do %>
           <%= govuk_visually_hidden('Induction') %> Extended
@@ -44,45 +52,69 @@
 
         <% row.with_value(text: "No") %>
 
-        <%= row.with_action(text: "Add", visually_hidden_text: "an extension", href: "#") %>
+        <% row.with_action(text: "Add", visually_hidden_text: "an extension", href: "#") %>
       <% end %>
+    <% end %>
+
+    <% sl.with_row do |row| %>
+      <% row.with_key(text: "Initial teacher training records") %>
+
+      <% row.with_value do %>
+        Future Teaching Scholars,<br/>
+        Maths and English, ages 5-11<br/>
+      <% end %>
+
+      <% row.with_action(text: "View", visually_hidden_text: "ITT records", href: ab_teacher_initial_teacher_training_records_path(@teacher), classes: 'govuk-link--no-visited-state') %>
     <% end %>
   <% end %>
 
-  <h2 class="govuk-heading-m">Induction periods</h2>
+  <h2 class="govuk-heading-m">Current induction period</h2>
 
-  <% @teacher.induction_periods.each.with_index(1).reverse_each do |induction_period, i| %>
-    <%=
-      govuk_summary_list(card: { title: "Induction period #{i}", actions: [govuk_link_to("Edit", "#")] }) do |sl|
+  <%=
+    govuk_summary_list(card: { title: @current_induction_period.appropriate_body.name, actions: [govuk_link_to('Release', new_ab_teacher_release_ect_path(@teacher), no_visited_state: true)] }) do |sl|
+      sl.with_row do |row|
+        row.with_key(text: "Induction programme")
+        row.with_value(text: induction_programme_choice_name(@current_induction_period.induction_programme))
+        row.with_action(text: 'Change', href: '#', visually_hidden_text: 'induction programme', classes: 'govuk-link--no-visited-state')
+      end
+
+      sl.with_row do |row|
+        row.with_key(text: "Start date")
+        row.with_value(text: @current_induction_period.started_on.to_fs(:govuk))
+      end
+    end
+  %>
+
+<% end %>
+
+<h2 class="govuk-heading-m">Past induction periods</h2>
+
+<% @past_induction_periods.each.with_index(1).reverse_each do |induction_period, i| %>
+  <%=
+    govuk_summary_list(actions: false, card: { title: induction_period.appropriate_body.name }) do |sl|
+      sl.with_row do |row|
+        row.with_key(text: "Induction programme")
+        row.with_value(text: induction_programme_choice_name(induction_period.induction_programme))
+      end
+
+      sl.with_row do |row|
+        row.with_key(text: "Start date")
+        row.with_value(text: induction_period.started_on.to_fs(:govuk))
+      end
+
+      if induction_period.finished_on.present?
         sl.with_row do |row|
-          row.with_key(text: "Appropriate body")
-          row.with_value(text: induction_period.appropriate_body.name)
-        end
-
-        sl.with_row do |row|
-          row.with_key(text: "Induction programme")
-          row.with_value(text: induction_programme_choice_name(induction_period.induction_programme))
-        end
-
-        if induction_period.number_of_terms.present?
-          sl.with_row do |row|
-            row.with_key(text: "Number of terms")
-            row.with_value(text: induction_period.number_of_terms)
-          end
-        end
-
-        sl.with_row do |row|
-          row.with_key(text: "Start date")
-          row.with_value(text: induction_period.started_on.to_fs(:govuk))
-        end
-
-        if induction_period.finished_on.present?
-          sl.with_row do |row|
-            row.with_key(text: "End date")
-            row.with_value(text: induction_period.finished_on.to_fs(:govuk))
-          end
+          row.with_key(text: "End date")
+          row.with_value(text: induction_period.finished_on.to_fs(:govuk))
         end
       end
-    %>
-  <% end %>
+
+      if induction_period.number_of_terms.present?
+        sl.with_row do |row|
+          row.with_key(text: "Number of terms")
+          row.with_value(text: induction_period.number_of_terms)
+        end
+      end
+    end
+  %>
 <% end %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -19,4 +19,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "OTP"  # One-time Password
   inflect.acronym "TRN"  # Teacher Reference Number
   inflect.acronym "TRS"  # Teaching Record System
+  inflect.acronym "ITT"  # Initial teacher training
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
       resource :record_failed_outcome, only: %i[new create show], path: 'record-failed-outcome', controller: 'teachers/record_failed_outcome'
 
       resources :extensions, controller: 'teachers/extensions', only: :index
+      resources :initial_teacher_training_records, path: 'itt-data', controller: 'teachers/initial_teacher_training_records', only: :index
     end
 
     namespace :claim_an_ect, path: 'claim-an-ect' do

--- a/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Recording a failed outcome for an ECT" do
 
   scenario 'Happy path' do
     given_i_am_on_the_ect_page(trn)
-    when_i_click_link('Record failed outcome')
+    when_i_click_link('Fail induction')
     then_i_should_be_on_the_record_outcome_page(trn)
 
     when_i_enter_the_finish_date

--- a/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Recording a passed outcome for an ECT" do
 
   scenario 'Happy path' do
     given_i_am_on_the_ect_page(trn)
-    when_i_click_link('Record passed outcome')
+    when_i_click_link('Pass induction')
     then_i_should_be_on_the_record_outcome_page(trn)
 
     when_i_enter_the_finish_date

--- a/spec/features/appropriate_bodies/release_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/release_an_ect_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Releasing an ECT' do
 
   scenario 'Happy path' do
     given_i_am_on_the_ect_page(trn)
-    when_i_click_link('Release ECT')
+    when_i_click_link('Release')
     then_i_should_be_on_the_release_ect_page(trn)
 
     when_i_submit_the_form_without_filling_anything_in


### PR DESCRIPTION
This is another batch of UI tweaks (similar to #738) which make some small changes to the teacher pages on the AB side.

![image](https://github.com/user-attachments/assets/b0188c25-1766-4f76-b2ea-15feeae3e610)

## Key changes

* add a summary of the ITT data to the induction summary
* separated the list of induction periods into current and past
* re-added the status based on @claire-hughez's points on Slack :) 