### PR TITLE
Fix pass and fail recording for appropriate bodies

### DIFF
--- a/app/controllers/appropriate_bodies/teachers/record_failed_outcome_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_failed_outcome_controller.rb
@@ -22,7 +22,10 @@ module AppropriateBodies
 
         PendingInductionSubmission.transaction do
           if @pending_induction_submission.save(context: :record_outcome) && record_outcome.fail!
-            redirect_to ab_teacher_record_failed_outcome_path(@teacher)
+            redirect_to(
+              ab_teacher_record_failed_outcome_path(@teacher),
+              flash: { teacher_name: ::Teachers::Name.new(@teacher).full_name }
+            )
           else
             render :new
           end
@@ -30,7 +33,7 @@ module AppropriateBodies
       end
 
       def show
-        @teacher = find_teacher
+        @teacher_name = flash['teacher_name']
       end
 
     private

--- a/app/controllers/appropriate_bodies/teachers/record_passed_outcome_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_passed_outcome_controller.rb
@@ -21,7 +21,10 @@ module AppropriateBodies
 
         PendingInductionSubmission.transaction do
           if @pending_induction_submission.save(context: :record_outcome) && record_outcome.pass!
-            redirect_to ab_teacher_record_passed_outcome_path(@teacher)
+            redirect_to(
+              ab_teacher_record_passed_outcome_path(@teacher),
+              flash: { teacher_name: ::Teachers::Name.new(@teacher).full_name }
+            )
           else
             render :new
           end
@@ -29,7 +32,7 @@ module AppropriateBodies
       end
 
       def show
-        @teacher = find_teacher
+        @teacher_name = flash['teacher_name']
       end
 
     private

--- a/app/views/appropriate_bodies/teachers/record_failed_outcome/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/record_failed_outcome/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= govuk_panel(
   title_text: "Success",
-  text: "You have recorded a failing outcome for #{Teachers::Name.new(@teacher).full_name}"
+  text: "You have recorded a failing outcome for #{@teacher_name}"
 ) %>
 
 <%= govuk_button_link_to("Return to the homepage", ab_teachers_path, secondary: true) %>

--- a/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe "Recording a failed outcome for an ECT" do
 
   before do
     sign_in_as_appropriate_body_user
-    allow_any_instance_of(AppropriateBodies::RecordOutcome).to receive(:fail!).and_call_original
-
-    @fake_record_outcome = instance_double(AppropriateBodies::RecordOutcome, fail!: true)
-    allow(AppropriateBodies::RecordOutcome).to receive(:new).and_return(@fake_record_outcome)
   end
 
   let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body: @appropriate_body) }
@@ -26,7 +22,7 @@ RSpec.describe "Recording a failed outcome for an ECT" do
 
     then_i_should_be_on_the_success_page
     and_the_pending_induction_submission_record_should_have_the_right_data_in_it
-    and_the_record_outcome_service_should_have_been_called
+    and_the_induction_period_should_have_been_closed_with_the_right_data
   end
 
 private
@@ -76,7 +72,11 @@ private
     expect(pending_induction_submission.outcome).to eql('fail')
   end
 
-  def and_the_record_outcome_service_should_have_been_called
-    expect(@fake_record_outcome).to have_received(:fail!).once
+  def and_the_induction_period_should_have_been_closed_with_the_right_data
+    induction_period.reload
+
+    expect(induction_period.outcome).to eql('fail')
+    expect(induction_period.number_of_terms).to eql(number_of_completed_terms)
+    expect(induction_period.finished_on).to eql(today)
   end
 end

--- a/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe "Recording a passed outcome for an ECT" do
 
   before do
     sign_in_as_appropriate_body_user
-    allow_any_instance_of(AppropriateBodies::RecordOutcome).to receive(:pass!).and_call_original
-
-    @fake_record_outcome = instance_double(AppropriateBodies::RecordOutcome, pass!: true)
-    allow(AppropriateBodies::RecordOutcome).to receive(:new).and_return(@fake_record_outcome)
   end
 
   let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body: @appropriate_body) }
@@ -26,7 +22,7 @@ RSpec.describe "Recording a passed outcome for an ECT" do
 
     then_i_should_be_on_the_success_page
     and_the_pending_induction_submission_record_should_have_the_right_data_in_it
-    and_the_record_outcome_service_should_have_been_called
+    and_the_induction_period_should_have_been_closed_with_the_right_data
   end
 
 private
@@ -76,7 +72,11 @@ private
     expect(pending_induction_submission.outcome).to eql('pass')
   end
 
-  def and_the_record_outcome_service_should_have_been_called
-    expect(@fake_record_outcome).to have_received(:pass!).once
+  def and_the_induction_period_should_have_been_closed_with_the_right_data
+    induction_period.reload
+
+    expect(induction_period.outcome).to eql('pass')
+    expect(induction_period.number_of_terms).to eql(number_of_completed_terms)
+    expect(induction_period.finished_on).to eql(today)
   end
 end


### PR DESCRIPTION
This was broken by the change in #790 that limits visible ECTs to those who are owned by the AB, and both passing and failing ECTs means they're no longer owned by the 'Success' page, so it breaks.

The tests didn't pick that up because they were mocking the actual closure of the induction period, so that's been removed and the actual final induction period is checked.
