### PR TITLE
Add extra spacing to the TRN field in the AB claim flow

### DIFF
--- a/app/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb
@@ -17,6 +17,7 @@
       width: 10,
       label: { text: "Teacher reference number (TRN)", size: "m" },
       hint: { text: "Enter your ECT's TRN (they are 7 digits long). It's on their pay slip, teaching contract or registration document from the General Teaching Council for England (GTCE)." },
+      extra_letter_spacing: true
     )
   %>
 

--- a/app/views/schools/register_ect/find_ect.html.erb
+++ b/app/views/schools/register_ect/find_ect.html.erb
@@ -9,6 +9,7 @@
         :trn,
         label: { text: "Teacher reference number (TRN)", size: "m" },
         hint: { text: "Enter your ECT's TRN (they are 7 digits long). It's on their pay slip, teaching contract or registration document from the General Teaching Council for England (GTCE).", size: "s" },
+        extra_letter_spacing: true
       )
   %>
 

--- a/app/views/schools/register_mentor/find_mentor.html.erb
+++ b/app/views/schools/register_mentor/find_mentor.html.erb
@@ -9,6 +9,7 @@
         :trn,
         label: { text: "Teacher reference number (TRN)", size: "m" },
         hint: { text: "This unique ID is usually 7 digits long, for example 4567814. It may also include letters or a slash, for example RP99/12345. It can be found on their payslip, teaching contract or registration document from the GTCE.", size: "s" },
+        extra_letter_spacing: true
       )
   %>
 


### PR DESCRIPTION
The spacing makes longer numbers/codes easier to read and for users to double check.

I can't find where it's referenced in the official Design System docs but here's the corresponding section of [the components guide](https://govuk-form-builder.netlify.app/form-elements/text-input/#inputs-with-extra-spacing-between-letters).

| Before | After |
| ----- | ----- |
| ![Screenshot From 2024-11-30 20-58-03](https://github.com/user-attachments/assets/d284eba1-abe9-4872-b56d-53d5a6b16e4f) |![Screenshot From 2024-11-30 20-58-10](https://github.com/user-attachments/assets/1529a6c7-8cf9-4a8a-80b7-30cdcc4d6f86) |

Extra issue for the hint to be removed added in #851.