### PR TITLE
Add a link to our design history to the service manual index

### DIFF
--- a/documentation/site/content/index.html
+++ b/documentation/site/content/index.html
@@ -50,4 +50,5 @@ title: Early career framework documentation
 
 <ul class="govuk-list">
   <li><a class="govuk-link--no-visited-state" href="/glossary/">Glossary</a></li>
+  <li><a class="govuk-link--no-visited-state" href="https://teacher-cpd.design-history.education.gov.uk/ecf-v2/">Design history</a></li>
 </ul>


### PR DESCRIPTION
We thought it would be helpful to make this change, so everything is in 1 place.