### PR TITLE
Fix Terraform resource names

### DIFF
--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -4,7 +4,7 @@
     "environment": "production",
     "enable_postgres_backup_storage": true,
     "enable_monitoring": true,
-    "external_url": "https://calculate-teacher-pay.education.gov.uk/healthcheck",
+    "external_url": "https://register-early-career-teachers.education.gov.uk/healthcheck",
     "statuscake_contact_groups": [
         291418
     ],


### PR DESCRIPTION
Production is currently [failing to deploy](https://github.com/DFE-Digital/register-early-career-teachers/actions/runs/12146232744/job/33870024501). This PR aims to fix it.

## Changes

- **Set register ECTs as the external_url in prod**
- **Convert external urls to list**

## Still to fix

We're getting this error:

> Error: Error: Resource Group "s189p01-cpdec2-mn-rg" was not found
> 
> with module.postgres.data.azurerm_resource_group.monitoring[0],
> on vendor/modules/aks/aks/postgres/data.tf line 22, in data "azurerm_resource_group" "monitoring":
> 22: data "azurerm_resource_group" "monitoring" ***

I'm unfamilar with `mn-rg`, but assuming as this is production that should be `pd-rg`? cc @vipin-dfe
