### PR TITLE
Fix the capitalisation of the Ecf2 module

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ require "action_view/railtie"
 
 Bundler.require(*Rails.groups)
 
-module Ecf2
+module ECF2
   class Application < Rails::Application
     config.load_defaults 7.1
     config.autoload_lib(ignore: %w[assets tasks])


### PR DESCRIPTION
This was generated before we added the ECF inflection, so changing it makes it consistent with the rest of the app.
