### PR TITLE
Rename `enable_postgres_backup_storage` to `azure_enable_backup_storage` for consistency

### DIFF
--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -2,7 +2,6 @@
     "cluster": "production",
     "namespace": "cpd-production",
     "environment": "production",
-    "enable_postgres_backup_storage": true,
     "enable_monitoring": true,
     "external_url": "https://register-early-career-teachers.education.gov.uk/healthcheck",
     "statuscake_contact_groups": [

--- a/config/terraform/application/database.tf
+++ b/config/terraform/application/database.tf
@@ -10,7 +10,7 @@ module "postgres" {
   cluster_configuration_map      = module.cluster_data.configuration_map
   use_azure                      = var.deploy_azure_backing_services
   azure_enable_monitoring        = var.enable_monitoring
-  azure_enable_backup_storage    = var.enable_postgres_backup_storage
+  azure_enable_backup_storage    = var.azure_enable_backup_storage
   server_version                 = "16"
   azure_extensions               = ["btree_gin", "citext", "plpgsql", "pg_trgm", "unaccent"]
   azure_enable_high_availability = var.postgres_enable_high_availability

--- a/config/terraform/application/variables.tf
+++ b/config/terraform/application/variables.tf
@@ -48,7 +48,7 @@ variable "enable_postgres_ssl" {
   default     = true
   description = "Enforce SSL connection from the client side"
 }
-variable "enable_postgres_backup_storage" {
+variable "azure_enable_backup_storage" {
   default     = false
   description = "Create a storage account to store database dumps"
 }


### PR DESCRIPTION
This mismatch caused a problem when deploying with the confusion being caused by us referring to it as `enable_postgres_backup_storage` and the shared Terraform module calling it `azure_enable_backup_storage`.

Here we rename it on our side for consistency.
