### PR TITLE
Update TRN validation

### DIFF
--- a/app/views/schools/register_ect/find_ect.html.erb
+++ b/app/views/schools/register_ect/find_ect.html.erb
@@ -5,7 +5,7 @@
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_number_field(
+  <%= f.govuk_text_field(
         :trn,
         label: { text: "Teacher reference number (TRN)", size: "m" },
         hint: { text: "Must be 7 digits long", size: "s" },

--- a/app/wizards/schools/register_ect/find_ect_step.rb
+++ b/app/wizards/schools/register_ect/find_ect_step.rb
@@ -35,7 +35,8 @@ module Schools
       end
 
       def trs_teacher
-        @trs_teacher ||= fetch_trs_teacher(trn:)
+        formatted_trn = Validation::TeacherReferenceNumber.new(trn).formatted_trn
+        @trs_teacher ||= fetch_trs_teacher(trn: formatted_trn)
       end
     end
   end


### PR DESCRIPTION
### Ticket
https://github.com/DFE-Digital/register-early-career-teachers/issues/835 

### Changes
We had already lifted the TRN validator from ECF1 however we were not allowing users to enter old-style TRN numbers in the Register ECT flow. This PR makes the following changes:

- Change the TRN field in the form into a text field so that users can enter old style numbers
- Pass the 'formatted' TRN to the TRS API 

