### PR TITLE
Register ECT - allow user to enter ECT's correct name

### DIFF
--- a/app/views/schools/register_ect_wizard/check_answers.html.erb
+++ b/app/views/schools/register_ect_wizard/check_answers.html.erb
@@ -24,7 +24,7 @@
 end %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
-  <%= f.govuk_error_summary %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <%= f.govuk_submit "Confirm details" %>
 <% end %>

--- a/app/views/schools/register_ect_wizard/review_ect_details.html.erb
+++ b/app/views/schools/register_ect_wizard/review_ect_details.html.erb
@@ -25,7 +25,20 @@
 end %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
-  <%= f.govuk_error_summary %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+  <%= f.govuk_radio_buttons_fieldset :change_name, legend: { text: "Are these details correct for the ECT?" } do %>
+    <%= f.govuk_radio_button :change_name, :no, label: { text: "Yes" }, link_errors: true %>
+    <%= f.govuk_radio_button :change_name, :yes, label: { text: "No, they changed their name or it's spelt wrong" } do %>
+      <%= f.govuk_text_field :corrected_name,
+                             label: {
+                               text: "Enter the correct full name"
+                             },
+                             hint: {
+                               text: "The name you provide will be used for ECT registration. The ECT can update their name in their teacher record later using the Access your teaching qualification service."
+                             } %>
+    <% end %>
+  <% end %>
 
   <%= f.govuk_submit "Confirm and continue" %>
 <% end %>

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -3,7 +3,7 @@ module Schools
     class ECT < SimpleDelegator
       # This class is a decorator for the SessionRepository
       def full_name
-        [trs_first_name, trs_last_name].join(" ").strip
+        corrected_name || [trs_first_name, trs_last_name].join(" ").strip
       end
 
       def govuk_date_of_birth

--- a/app/wizards/schools/register_ect_wizard/review_ect_details_step.rb
+++ b/app/wizards/schools/register_ect_wizard/review_ect_details_step.rb
@@ -3,6 +3,15 @@
 module Schools
   module RegisterECTWizard
     class ReviewECTDetailsStep < Step
+      attr_accessor :change_name, :corrected_name
+
+      validates :change_name, presence: { message: "Select 'Yes' or 'No' to confirm whether the details are correct" }
+      validates :corrected_name, presence: { message: "Enter the full, correct name" }, if: -> { change_name == "yes" }
+
+      def self.permitted_params
+        %i[change_name corrected_name]
+      end
+
       def next_step
         :email_address
       end

--- a/spec/features/schools/register_an_ect/happy_path_spec.rb
+++ b/spec/features/schools/register_an_ect/happy_path_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe 'Registering an ECT' do
     then_i_should_be_taken_to_the_review_ect_details_page
     and_i_should_see_the_ect_details_in_the_review_page
 
-    when_i_click_confirm_and_continue
+    when_i_select_that_my_ect_name_is_incorrect
+    and_i_enter_the_corrected_name
+    and_i_click_confirm_and_continue
     then_i_should_be_taken_to_the_email_address_page
 
     when_i_enter_the_ect_email_address
@@ -78,7 +80,15 @@ RSpec.describe 'Registering an ECT' do
     expect(page.get_by_text("1 December 2000")).to be_visible
   end
 
-  def when_i_click_confirm_and_continue
+  def when_i_select_that_my_ect_name_is_incorrect
+    page.get_by_label("No, they changed their name or it's spelt wrong").check
+  end
+
+  def and_i_enter_the_corrected_name
+    page.get_by_label('Enter the correct full name').fill('Kirk Van Damme')
+  end
+
+  def and_i_click_confirm_and_continue
     page.get_by_role('button', name: 'Confirm and continue').click
   end
 
@@ -100,7 +110,7 @@ RSpec.describe 'Registering an ECT' do
 
   def and_i_should_see_all_the_ect_data_on_the_page
     expect(page.get_by_text(trn)).to be_visible
-    expect(page.get_by_text("Kirk Van Houten")).to be_visible
+    expect(page.get_by_text("Kirk Van Damme")).to be_visible
     expect(page.get_by_text("1 December 2000")).to be_visible
     expect(page.get_by_text('example@example.com')).to be_visible
   end

--- a/spec/wizards/schools/register_ect/ect_spec.rb
+++ b/spec/wizards/schools/register_ect/ect_spec.rb
@@ -11,7 +11,8 @@ describe Schools::RegisterECTWizard::ECT do
                      trs_date_of_birth: "1945-10-11",
                      trs_national_insurance_number: "OWAD23455",
                      email: "dusty@rhodes.com",
-                     school_urn: school.urn)
+                     school_urn: school.urn,
+                     corrected_name: nil)
   end
 
   subject(:ect) { described_class.new(store) }


### PR DESCRIPTION
### Ticket
https://github.com/DFE-Digital/register-early-career-teachers/issues/780

### Changes
- Allow user to enter the ECT's correct name in the Register ECT flow

### Note
A followup PR will be required to playback the corrected name on the ECT home page once #859 is merged (write ect session data to the db)

### Video

https://github.com/user-attachments/assets/063e00f9-04e8-4822-bd27-4087679c45c0

