### PR TITLE
Adding more info for viewing failures

### DIFF
--- a/app/components/migration/migration_failure_component.html.erb
+++ b/app/components/migration/migration_failure_component.html.erb
@@ -1,0 +1,6 @@
+<div class="migration-failure">
+  <h3 class="govuk-heading-s"><%= description %></h3>
+  <div class="migration-row">
+    <%= render Migration::ParticipantProfileComponent.new(participant_profile:) %>
+  </div>
+</div>

--- a/app/components/migration/migration_failure_component.html.erb
+++ b/app/components/migration/migration_failure_component.html.erb
@@ -3,4 +3,9 @@
   <div class="migration-row">
     <%= render Migration::ParticipantProfileComponent.new(participant_profile:) %>
   </div>
+  <% induction_records.each do |induction_record| %>
+    <div class="migration-row">
+      <%= render Migration::InductionRecordComponent.new(induction_record:) %>
+    </div>
+  <% end %>
 </div>

--- a/app/components/migration/migration_failure_component.rb
+++ b/app/components/migration/migration_failure_component.rb
@@ -10,9 +10,7 @@ module Migration
       migration_failure.failure_type
     end
 
-    def participant_profile
-      migration_failure.participant_profile
-    end
+    delegate :participant_profile, to: :migration_failure
 
     def induction_records
       participant_profile&.induction_records || []

--- a/app/components/migration/migration_failure_component.rb
+++ b/app/components/migration/migration_failure_component.rb
@@ -1,0 +1,17 @@
+module Migration
+  class MigrationFailureComponent < ViewComponent::Base
+    attr_reader :migration_failure
+
+    def initialize(migration_failure:)
+      @migration_failure = Migration::MigrationFailurePresenter.new(migration_failure)
+    end
+
+    def description
+      migration_failure.failure_type
+    end
+
+    def participant_profile
+      migration_failure.participant_profile
+    end
+  end
+end

--- a/app/components/migration/migration_failure_component.rb
+++ b/app/components/migration/migration_failure_component.rb
@@ -13,5 +13,9 @@ module Migration
     def participant_profile
       migration_failure.participant_profile
     end
+
+    def induction_records
+      participant_profile&.induction_records || []
+    end
   end
 end

--- a/app/components/migration/participant_profile_component.html.erb
+++ b/app/components/migration/participant_profile_component.html.erb
@@ -6,11 +6,11 @@
     end
     list.with_row(**attributes_for(:sparsity_uplift)) do |row|
       row.with_key(text: "Sparsity uplift")
-      row.with_value(text: participant_profile.sparsity_uplift)
+      row.with_value(text: participant_profile.sparsity_uplift.to_s)
     end
     list.with_row(**attributes_for(:pupil_premium_uplift)) do |row|
       row.with_key(text: "Pupil premium uplift")
-      row.with_value(text: participant_profile.pupil_premium_uplift)
+      row.with_value(text: participant_profile.pupil_premium_uplift.to_s)
     end
     list.with_row(**attributes_for(:status)) do |row|
       row.with_key(text: "Status")
@@ -49,7 +49,7 @@
     end
     list.with_row do |row|
       row.with_key(text: "Cohort changed after payments frozen")
-      row.with_value(text: participant_profile.cohort_changed_after_payments_frozen)
+      row.with_value(text: participant_profile.cohort_changed_after_payments_frozen.to_s)
     end
   end
 end %>

--- a/app/components/migration/participant_profile_component.html.erb
+++ b/app/components/migration/participant_profile_component.html.erb
@@ -1,0 +1,55 @@
+<%= govuk_summary_card(title: "Participant profile (#{participant_profile.participant_type})") do |card|
+  card.with_summary_list(html_attributes: { class: "govuk-!-font-size-14" }) do |list|
+    list.with_row do |row|
+      row.with_key(text: "ID")
+      row.with_value(text: participant_profile.id)
+    end
+    list.with_row(**attributes_for(:sparsity_uplift)) do |row|
+      row.with_key(text: "Sparsity uplift")
+      row.with_value(text: participant_profile.sparsity_uplift)
+    end
+    list.with_row(**attributes_for(:pupil_premium_uplift)) do |row|
+      row.with_key(text: "Pupil premium uplift")
+      row.with_value(text: participant_profile.pupil_premium_uplift)
+    end
+    list.with_row(**attributes_for(:status)) do |row|
+      row.with_key(text: "Status")
+      row.with_value(text: participant_profile.status)
+    end
+    list.with_row(**attributes_for(:training_status)) do |row|
+      row.with_key(text: "Training status")
+      row.with_value(text: participant_profile.training_status)
+    end
+    list.with_row do |row|
+      row.with_key(text: "Cohort")
+      row.with_value(text: school_cohort_year)
+    end
+    list.with_row do |row|
+      row.with_key(text: "School")
+      row.with_value(text: school_name_and_urn)
+    end
+    if ect?
+      list.with_row do |row|
+        row.with_key(text: "Induction start date")
+        row.with_value(text: participant_profile.induction_start_date)
+      end
+      list.with_row do |row|
+        row.with_key(text: "Induction completion date")
+        row.with_value(text: participant_profile.induction_completion_date)
+      end
+    else
+      list.with_row do |row|
+        row.with_key(text: "Mentor completion date")
+        row.with_value(text: participant_profile.mentor_completion_date)
+      end
+      list.with_row do |row|
+        row.with_key(text: "Mentor completion reason")
+        row.with_value(text: participant_profile.mentor_completion_reason)
+      end
+    end
+    list.with_row do |row|
+      row.with_key(text: "Cohort changed after payments frozen")
+      row.with_value(text: participant_profile.cohort_changed_after_payments_frozen)
+    end
+  end
+end %>

--- a/app/components/migration/participant_profile_component.rb
+++ b/app/components/migration/participant_profile_component.rb
@@ -18,9 +18,7 @@ module Migration
       @school ||= participant_profile.school_cohort.school
     end
 
-    def ect?
-      participant_profile.ect?
-    end
+    delegate :ect?, to: :participant_profile
 
     def attributes_for(_attr)
       {}

--- a/app/components/migration/participant_profile_component.rb
+++ b/app/components/migration/participant_profile_component.rb
@@ -1,0 +1,29 @@
+module Migration
+  class ParticipantProfileComponent < ViewComponent::Base
+    attr_reader :participant_profile
+
+    def initialize(participant_profile:)
+      @participant_profile = Migration::ParticipantProfilePresenter.new(participant_profile)
+    end
+
+    def school_cohort_year
+      participant_profile.school_cohort.cohort.start_year
+    end
+
+    def school_name_and_urn
+      Schools::Name.new(school).name_and_urn
+    end
+
+    def school
+      @school ||= participant_profile.school_cohort.school
+    end
+
+    def ect?
+      participant_profile.ect?
+    end
+
+    def attributes_for(_attr)
+      {}
+    end
+  end
+end

--- a/app/components/migration/participant_profile_component.rb
+++ b/app/components/migration/participant_profile_component.rb
@@ -25,5 +25,9 @@ module Migration
     def attributes_for(_attr)
       {}
     end
+
+    def render?
+      participant_profile.present?
+    end
   end
 end

--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -3,14 +3,13 @@ module Admin
     layout "full"
 
     def index
-      @pagy, @teachers = pagy(Teachers::Search.new(params[:q]).search.order(:last_name, :first_name, :id))
+      @pagy, teachers = pagy(Teachers::Search.new(params[:q]).search.order(:last_name, :first_name, :id))
+      @teachers = TeacherPresenter.wrap(teachers)
     end
 
     def show
       @page = params[:page] || 1
       @teacher = TeacherPresenter.new(Teacher.find_by(trn: params[:id]))
-      @ect_periods = SchoolPeriodPresenter.wrap(@teacher.ect_at_school_periods.order(started_on: :desc)) if @teacher.ect?
-      @mentor_periods = SchoolPeriodPresenter.wrap(@teacher.mentor_at_school_periods.order(started_on: :desc)) if @teacher.mentor?
     end
   end
 end

--- a/app/controllers/migration/failures_controller.rb
+++ b/app/controllers/migration/failures_controller.rb
@@ -2,7 +2,7 @@ class Migration::FailuresController < ::AdminController
   layout "full"
 
   def index
-    @pagy, failures = pagy(MigrationFailure.where(data_migration_id: DataMigration.where(model: params[:model]).select(:id)).order(:parent_id,:created_at))
+    @pagy, failures = pagy(MigrationFailure.where(data_migration_id: DataMigration.where(model: params[:model]).select(:id)).order(:parent_id, :created_at))
     @migration_failures = Migration::MigrationFailurePresenter.wrap(failures)
     @model = params[:model]
   end

--- a/app/controllers/migration/failures_controller.rb
+++ b/app/controllers/migration/failures_controller.rb
@@ -2,7 +2,8 @@ class Migration::FailuresController < ::AdminController
   layout "full"
 
   def index
-    @migration_failures = MigrationFailure.where(data_migration_id: DataMigration.where(model: params[:model]).select(:id))
+    @pagy, failures = pagy(MigrationFailure.where(data_migration_id: DataMigration.where(model: params[:model]).select(:id)).order(:parent_id,:created_at))
+    @migration_failures = Migration::MigrationFailurePresenter.wrap(failures)
     @model = params[:model]
   end
 end

--- a/app/controllers/migration/teachers_controller.rb
+++ b/app/controllers/migration/teachers_controller.rb
@@ -15,6 +15,13 @@ private
     mentor_profile
     ect_school_periods
     mentor_school_periods
+    failures
+  end
+
+  def failures
+    @failures = Migration::MigrationFailurePresenter.wrap(
+      MigrationFailure.where(parent_type: "Teacher", parent_id: @teacher.id)
+    )
   end
 
   def ect_school_periods

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -2,4 +2,12 @@ module AdminHelper
   def admin_sub_navigation_structure
     @admin_sub_navigation_structure ||= Navigation::Structures::AdminSubNavigation.new.get
   end
+
+  def admin_teacher_name_link(teacher)
+    govuk_link_to(Teachers::Name.new(teacher).full_name, admin_teacher_path(teacher))
+  end
+
+  def admin_teachers_list_links(teachers)
+    govuk_list(teachers.map { |teacher| admin_teacher_name_link(teacher) })
+  end
 end

--- a/app/migration/induction_record_sanitizer.rb
+++ b/app/migration/induction_record_sanitizer.rb
@@ -1,7 +1,12 @@
 class InductionRecordSanitizer
   include Enumerable
 
-  class InductionRecordError < StandardError; end
+  class InductionRecordError < StandardError
+    def initialize(participant_profile_id)
+      msg = "#{self.class.name}|#{participant_profile_id}"
+      super(msg)
+    end
+  end
   class MultipleBlankEndDateError < InductionRecordError; end
   class MultipleActiveStatesError < InductionRecordError; end
   class StartDateAfterEndDateError < InductionRecordError; end
@@ -57,26 +62,26 @@ private
   end
 
   def has_induction_records!
-    raise NoInductionRecordsError if induction_records.empty?
+    raise NoInductionRecordsError.new(participant_profile.id) if induction_records.empty?
   end
 
   def does_not_have_multiple_blank_end_dates!
-    raise MultipleBlankEndDateError if induction_records.where(end_date: nil).count > 1
+    raise MultipleBlankEndDateError.new(participant_profile.id) if induction_records.where(end_date: nil).count > 1
   end
 
   def does_not_have_multiple_active_induction_statuses!
-    raise MultipleActiveStatesError if induction_records.where(induction_status: "active").count > 1
+    raise MultipleActiveStatesError.new(participant_profile.id) if induction_records.where(induction_status: "active").count > 1
   end
 
   def induction_record_dates_are_sequential!
     previous_end_date = induction_records.first.end_date
 
     induction_records.each_with_index do |ir, idx|
-      raise StartDateAfterEndDateError if ir.end_date.present? && ir.end_date < ir.start_date
+      raise StartDateAfterEndDateError.new(participant_profile.id) if ir.end_date.present? && ir.end_date < ir.start_date
 
       next if idx.zero?
 
-      raise InvalidDateSequenceError if previous_end_date.nil? || ir.start_date < previous_end_date
+      raise InvalidDateSequenceError.new(participant_profile.id) if previous_end_date.nil? || ir.start_date < previous_end_date
 
       previous_end_date = ir.end_date
     end

--- a/app/migration/induction_record_sanitizer.rb
+++ b/app/migration/induction_record_sanitizer.rb
@@ -7,6 +7,7 @@ class InductionRecordSanitizer
       super(msg)
     end
   end
+
   class MultipleBlankEndDateError < InductionRecordError; end
   class MultipleActiveStatesError < InductionRecordError; end
   class StartDateAfterEndDateError < InductionRecordError; end
@@ -62,26 +63,26 @@ private
   end
 
   def has_induction_records!
-    raise NoInductionRecordsError.new(participant_profile.id) if induction_records.empty?
+    raise(NoInductionRecordsError, participant_profile.id) if induction_records.empty?
   end
 
   def does_not_have_multiple_blank_end_dates!
-    raise MultipleBlankEndDateError.new(participant_profile.id) if induction_records.where(end_date: nil).count > 1
+    raise(MultipleBlankEndDateError, participant_profile.id) if induction_records.where(end_date: nil).count > 1
   end
 
   def does_not_have_multiple_active_induction_statuses!
-    raise MultipleActiveStatesError.new(participant_profile.id) if induction_records.where(induction_status: "active").count > 1
+    raise(MultipleActiveStatesError, participant_profile.id) if induction_records.where(induction_status: "active").count > 1
   end
 
   def induction_record_dates_are_sequential!
     previous_end_date = induction_records.first.end_date
 
     induction_records.each_with_index do |ir, idx|
-      raise StartDateAfterEndDateError.new(participant_profile.id) if ir.end_date.present? && ir.end_date < ir.start_date
+      raise(StartDateAfterEndDateError, participant_profile.id) if ir.end_date.present? && ir.end_date < ir.start_date
 
       next if idx.zero?
 
-      raise InvalidDateSequenceError.new(participant_profile.id) if previous_end_date.nil? || ir.start_date < previous_end_date
+      raise(InvalidDateSequenceError, participant_profile.id) if previous_end_date.nil? || ir.start_date < previous_end_date
 
       previous_end_date = ir.end_date
     end

--- a/app/migration/migrators/mentorship_period.rb
+++ b/app/migration/migrators/mentorship_period.rb
@@ -9,7 +9,7 @@ module Migrators
     end
 
     def self.ects
-      ::Teacher.where.associated(:ect_at_school_periods).distinct
+      ::Migration::ParticipantProfile.ect
     end
 
     def self.dependencies
@@ -23,13 +23,13 @@ module Migrators
     end
 
     def migrate!
-      migrate(self.class.ects) do |teacher|
-        migrate_mentorships!(teacher:)
+      migrate(self.class.ects) do |participant_profile|
+        migrate_mentorships!(participant_profile:)
       end
     end
 
-    def migrate_mentorships!(teacher:)
-      participant_profile = Migration::ParticipantProfile.find(teacher.legacy_ect_id)
+    def migrate_mentorships!(participant_profile:)
+      teacher = ::Teacher.find_by!(legacy_ect_id: participant_profile.id)
       induction_records = InductionRecordSanitizer.new(participant_profile:)
       induction_records.validate!
 

--- a/app/migration/migrators/teacher.rb
+++ b/app/migration/migrators/teacher.rb
@@ -9,7 +9,7 @@ module Migrators
     end
 
     def self.teachers
-      ::Migration::TeacherProfile.where(id: ::Migration::ParticipantProfile.ect_or_mentor.select(:teacher_profile_id).distinct)
+      ::Migration::TeacherProfile.joins(:participant_profiles).merge(Migration::ParticipantProfile.ect_or_mentor).distinct
     end
 
     def self.dependencies

--- a/app/models/migration/participant_profile.rb
+++ b/app/models/migration/participant_profile.rb
@@ -3,6 +3,7 @@ module Migration
     self.inheritance_column = nil
 
     belongs_to :teacher_profile
+    belongs_to :school_cohort
     has_many :induction_records
     has_many :school_mentors # only ParticipantProfile::Mentor
 

--- a/app/presenters/admin/mentorship_period_presenter.rb
+++ b/app/presenters/admin/mentorship_period_presenter.rb
@@ -1,0 +1,52 @@
+module Admin
+  class MentorshipPeriodPresenter < SimpleDelegator
+    def self.wrap(collection)
+      collection.map { |item| new(item) }
+    end
+
+    def mentor_name
+      Teachers::Name.new(mentor_teacher).full_name
+    end
+
+    def mentee_name
+      Teachers::Name.new(mentee_teacher).full_name
+    end
+
+    def mentor_single_line_summary
+      single_line_summary(mentor_teacher)
+    end
+
+    def mentee_single_line_summary
+      single_line_summary(mentee_teacher)
+    end
+
+    def formatted_started_on
+      mentorship_period.started_on.to_fs(:govuk)
+    end
+
+    def formatted_finished_on
+      return "" if mentorship_period.finished_on.blank?
+
+      mentorship_period.finished_on.to_fs(:govuk)
+    end
+
+  private
+
+    def mentorship_period
+      __getobj__
+    end
+
+    def mentor_teacher
+      @mentor_teacher ||= mentorship_period.mentor.teacher
+    end
+
+    def mentee_teacher
+      @mentee_teacher ||= mentorship_period.mentee.teacher
+    end
+
+    def single_line_summary(teacher)
+      "#{Teachers::Name.new(teacher).full_name} (#{formatted_started_on} - #{formatted_finished_on})"
+    end
+
+  end
+end

--- a/app/presenters/admin/mentorship_period_presenter.rb
+++ b/app/presenters/admin/mentorship_period_presenter.rb
@@ -47,6 +47,5 @@ module Admin
     def single_line_summary(teacher)
       "#{Teachers::Name.new(teacher).full_name} (#{formatted_started_on} - #{formatted_finished_on})"
     end
-
   end
 end

--- a/app/presenters/admin/school_period_presenter.rb
+++ b/app/presenters/admin/school_period_presenter.rb
@@ -23,7 +23,7 @@ module Admin
     end
 
     def mentees
-      school_period.mentorship_periods.ongoing.order(started_on: :desc).map { |mp| Teachers::Name.new(mp.mentee.teacher).full_name }
+      school_period.mentorship_periods.ongoing.map { |mp| mp.mentee.teacher }.sort(&:last_name)
     end
 
     def mentorship_periods

--- a/app/presenters/admin/school_period_presenter.rb
+++ b/app/presenters/admin/school_period_presenter.rb
@@ -18,6 +18,26 @@ module Admin
       school_period.finished_on.to_fs(:govuk)
     end
 
+    def latest_mentorship_period
+      mentorship_periods.first
+    end
+
+    def mentees
+      school_period.mentorship_periods.ongoing.order(started_on: :desc).map { |mp| Teachers::Name.new(mp.mentee.teacher).full_name }
+    end
+
+    def mentorship_periods
+      MentorshipPeriodPresenter.wrap(school_period.mentorship_periods.order(started_on: :desc))
+    end
+
+    def latest_training_period
+      training_periods.first
+    end
+
+    def training_periods
+      TrainingPeriodPresenter.wrap(school_period.training_periods.order(started_on: :desc))
+    end
+
   private
 
     def school_period

--- a/app/presenters/admin/teacher_presenter.rb
+++ b/app/presenters/admin/teacher_presenter.rb
@@ -1,5 +1,9 @@
 module Admin
   class TeacherPresenter < SimpleDelegator
+    def self.wrap(collection)
+      collection.map { |teacher| new(teacher) }
+    end
+
     def full_name
       Teachers::Name.new(teacher).full_name
     end
@@ -14,6 +18,28 @@ module Admin
 
     def mentor?
       teacher.mentor_at_school_periods.any?
+    end
+
+    def latest_school_period_as_an_ect
+      latest = school_periods_as_an_ect.first
+      SchoolPeriodPresenter.new(latest) if latest.present?
+    end
+
+    def school_periods_as_an_ect
+      teacher.ect_at_school_periods.order(started_on: :desc)
+    end
+
+    def latest_school_period_as_a_mentor
+      latest = school_periods_as_a_mentor.first
+      SchoolPeriodPresenter.new(latest) if latest.present?
+    end
+
+    def school_periods_as_a_mentor
+      teacher.mentor_at_school_periods.order(started_on: :desc)
+    end
+
+    def migration_failures
+      MigrationFailure.where(parent_id: teacher.id, parent_type: "Teacher").order(:id)
     end
 
   private

--- a/app/presenters/admin/training_period_presenter.rb
+++ b/app/presenters/admin/training_period_presenter.rb
@@ -1,0 +1,31 @@
+module Admin
+  class TrainingPeriodPresenter < SimpleDelegator
+    def self.wrap(collection)
+      collection.map { |item| new(item) }
+    end
+
+    def lead_provider
+      @lead_provider ||= training_period.provider_partnership.lead_provider
+    end
+
+    def delivery_partner
+      @delivery_partner ||= training_period.provider_partnership.delivery_partner
+    end
+
+    def formatted_started_on
+      training_period.started_on.to_fs(:govuk)
+    end
+
+    def formatted_finished_on
+      return "" if training_period.finished_on.blank?
+
+      training_period.finished_on.to_fs(:govuk)
+    end
+
+  private
+
+    def training_period
+      __getobj__
+    end
+  end
+end

--- a/app/presenters/migration/migration_failure_presenter.rb
+++ b/app/presenters/migration/migration_failure_presenter.rb
@@ -1,0 +1,64 @@
+module Migration
+  class MigrationFailurePresenter < SimpleDelegator
+    def self.wrap(collection)
+      collection.map { |record| new(record) }
+    end
+
+    def failure_type
+      @failure_type ||= friendly_error_type(parse_failure_message.first)
+    end
+
+    def participant_profile_id
+      pfm = parse_failure_message
+
+      if pfm.size == 2
+        pfm.last
+      else
+        nil
+      end
+    end
+
+    def participant_profile
+      return if participant_profile_id.nil?
+      @participant_profile ||= Migration::ParticipantProfile.find(participant_profile_id)
+    end
+
+    def parent
+      return if parent_id.blank?
+      return Teacher.find(parent_id) if parent_type == "Teacher"
+    end
+
+    def related_object_id
+      participant_profile_id || item["id"]
+    end
+
+  private
+
+    def migration_failure
+      __getobj__
+    end
+
+    def friendly_error_type(error_class)
+      case error_class
+      when "InductionRecordSanitizer::MultipleBlankEndDateError"
+        "More than 1 end date is blank in the Induction records"
+      when "InductionRecordSanitizer::MultipleActiveStatesError"
+        "More that 1 induction record with an active induction status"
+      when "InductionRecordSanitizer::StartDateAfterEndDateError"
+        "An induction record has a start date later than the end date"
+      when "InductionRecordSanitizer::InvalidDateSequenceError"
+        "The induction record dates are not sequential"
+      when "InductionRecordSanitizer::NoInductionRecordsError"
+        "The profile does not have any induction records"
+      else
+        error_class
+      end
+    end
+
+    def parse_failure_message
+      # exception class and id of context record
+      # currently only for induction record errors and participant_profile_id
+      failure_message.split("|")
+    end
+  end
+end

--- a/app/presenters/migration/migration_failure_presenter.rb
+++ b/app/presenters/migration/migration_failure_presenter.rb
@@ -15,19 +15,19 @@ module Migration
         pfm.last
       elsif parent.present?
         profile_id_from_parent
-      else
-        nil
       end
     end
 
     def participant_profile
       return if participant_profile_id.nil?
+
       @participant_profile ||= Migration::ParticipantProfilePresenter.new(Migration::ParticipantProfile.find(participant_profile_id))
     end
 
     def parent
       return if parent_id.blank?
-      return Teacher.find(parent_id) if parent_type == "Teacher"
+
+      Teacher.find(parent_id) if parent_type == "Teacher"
     end
 
     def related_object_id
@@ -43,13 +43,12 @@ module Migration
     def profile_id_from_parent
       return parent.legacy_ect_id if parent.legacy_ect_id.present?
       return parent.legacy_mentor_id if parent.legacy_mentor_id.present?
+
       if parent.legacy_id
         # NOTE: if they have both ECT and Mentor profiles we don't know which had the issue
         #       and we're only returning the first from the DB but it feels that might be better
         #       than nothing.
         Migration::User.find(parent.legacy_id).teacher_profile.participant_profiles.ect_or_mentor.first&.id
-      else
-        nil
       end
     end
 

--- a/app/presenters/migration/participant_profile_presenter.rb
+++ b/app/presenters/migration/participant_profile_presenter.rb
@@ -5,7 +5,7 @@ module Migration
     end
 
     def participant_type
-      type.split("::").last
+      participant_profile.type.split("::").last
     end
 
     def induction_records

--- a/app/presenters/migration/participant_profile_presenter.rb
+++ b/app/presenters/migration/participant_profile_presenter.rb
@@ -4,6 +4,10 @@ module Migration
       collection.map { |participant_profile| new(participant_profile) }
     end
 
+    def participant_type
+      type.split("::").last
+    end
+
     def induction_records
       @induction_records ||= fetch_induction_records
     end

--- a/app/services/schools/name.rb
+++ b/app/services/schools/name.rb
@@ -1,0 +1,13 @@
+module Schools
+  class Name
+    attr_accessor :school
+
+    def initialize(school)
+      @school = school
+    end
+
+    def name_and_urn
+      "#{school.name} (#{school.urn})"
+    end
+  end
+end

--- a/app/views/admin/teachers/index.html.erb
+++ b/app/views/admin/teachers/index.html.erb
@@ -22,6 +22,7 @@
         row.with_cell(text: "Name")
         row.with_cell(text: "Role")
         row.with_cell(text: "TRN")
+        row.with_cell { govuk_visually_hidden("Has migration errors") }
       end
     end
 
@@ -33,6 +34,11 @@
           end
           row.with_cell(text: Teachers::Role.new(teacher:))
           row.with_cell(text: teacher.trn)
+          if teacher.migration_failures.any?
+            row.with_cell { govuk_tag(text: "Error", colour: "red") }
+          else
+            row.with_cell(text: "")
+          end
         end
       end
     end

--- a/app/views/admin/teachers/show.html.erb
+++ b/app/views/admin/teachers/show.html.erb
@@ -31,7 +31,9 @@
   <%= govuk_summary_list do |sl|
     sl.with_row do |row|
       row.with_key(text: "School")
-      row.with_value(text: school_period.school_name_and_urn)
+      row.with_value do
+        govuk_link_to(school_period.school_name_and_urn, admin_school_path(school_period.school.urn))
+      end
     end
     sl.with_row do |row|
       row.with_key(text: "Started on")
@@ -74,7 +76,9 @@
   <%= govuk_summary_list do |sl|
     sl.with_row do |row|
       row.with_key(text: "School")
-      row.with_value(text: school_period.school_name_and_urn)
+      row.with_value do
+        govuk_link_to(school_period.school_name_and_urn, admin_school_path(school_period.school.urn))
+      end
     end
     sl.with_row do |row|
       row.with_key(text: "Started on")

--- a/app/views/admin/teachers/show.html.erb
+++ b/app/views/admin/teachers/show.html.erb
@@ -1,7 +1,6 @@
 <% page_data(title: @teacher.full_name, backlink_href: admin_teachers_path(page: @page)) %>
 
-<%=
-  govuk_summary_list do |sl|
+<%= govuk_summary_list do |sl|
     sl.with_row do |row|
       row.with_key(text: "Name")
       row.with_value(text: @teacher.full_name)
@@ -18,50 +17,81 @@
       # FIXME: This is a placeholder. The actual status should be displayed here.
       row.with_value(text: govuk_tag(text: "placeholder", colour: %w[grey green red purple orange yellow].sample))
     end
-  end
-%>
+  end %>
+
+<%= govuk_warning_text(text: "Some of this teacher's records could not be migrated") if @teacher.migration_failures.any? %>
+
 <% if @teacher.ect? %>
   <h3 class="govuk-heading-m">Early career teacher</h3>
-  <% @ect_periods.each do |school_period| %>
-    <%= govuk_summary_list do |sl|
-      sl.with_row do |row|
-        row.with_key(text: "School")
-        row.with_value(text: school_period.school_name_and_urn)
-      end
+  <%
+    school_period = @teacher.latest_school_period_as_an_ect
+    training_period = school_period.latest_training_period
+  %>
 
-      sl.with_row do |row|
-        row.with_key(text: "Started on")
-        row.with_value(text: school_period.formatted_started_on)
-      end
-
-      sl.with_row do |row|
-        row.with_key(text: "Finished on")
-        row.with_value(text: school_period.formatted_finished_on)
-      end
-    end %>
-  <% end %>
+  <%= govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "School")
+      row.with_value(text: school_period.school_name_and_urn)
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Started on")
+      row.with_value(text: school_period.formatted_started_on)
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Finished on")
+      row.with_value(text: school_period.formatted_finished_on)
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Mentor")
+      row.with_value(text: school_period.latest_mentorship_period.mentor_name)
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Lead provider")
+      row.with_value(text: training_period.lead_provider.name)
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Delivery partner")
+      row.with_value(text: training_period.delivery_partner.name)
+    end
+  end %>
+  <hr class="govuk-section-break govuk-section-break--l" />
 <% end %>
 
 <% if @teacher.mentor? %>
   <h3 class="govuk-heading-m">Mentor</h3>
-  <% @mentor_periods.each do |school_period| %>
-    <%= govuk_summary_list do |sl|
-      sl.with_row do |row|
-        row.with_key(text: "School")
-        row.with_value(text: school_period.school_name_and_urn)
-      end
+  <%
+    # FIXME: This should probably iterate over all ongoing school periods
+    school_period = @teacher.latest_school_period_as_a_mentor
+    training_period = school_period.latest_training_period
+  %>
 
-      sl.with_row do |row|
-        row.with_key(text: "Started on")
-        row.with_value(text: school_period.formatted_started_on)
-      end
-
-      sl.with_row do |row|
-        row.with_key(text: "Finished on")
-        row.with_value(text: school_period.formatted_finished_on)
-      end
-    end %>
-  <% end %>
+  <%= govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "School")
+      row.with_value(text: school_period.school_name_and_urn)
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Started on")
+      row.with_value(text: school_period.formatted_started_on)
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Finished on")
+      row.with_value(text: school_period.formatted_finished_on)
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Mentees")
+      row.with_value(text: school_period.mentees.join(", "))
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Lead provider")
+      row.with_value(text: training_period.lead_provider.name)
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Delivery partner")
+      row.with_value(text: training_period.delivery_partner.name)
+    end
+  end %>
+  <hr class="govuk-section-break govuk-section-break--l" />
 <% end %>
 
 <p class="govuk-body">

--- a/app/views/admin/teachers/show.html.erb
+++ b/app/views/admin/teachers/show.html.erb
@@ -43,15 +43,21 @@
     end
     sl.with_row do |row|
       row.with_key(text: "Mentor")
-      row.with_value(text: school_period.latest_mentorship_period.mentor_name)
+      row.with_value do
+        if school_period.latest_mentorship_period.present?
+          admin_teacher_name_link(school_period.latest_mentorship_period.mentor.teacher)
+        else
+          ""
+        end
+      end
     end
     sl.with_row do |row|
       row.with_key(text: "Lead provider")
-      row.with_value(text: training_period.lead_provider.name)
+      row.with_value(text: training_period&.lead_provider&.name)
     end
     sl.with_row do |row|
       row.with_key(text: "Delivery partner")
-      row.with_value(text: training_period.delivery_partner.name)
+      row.with_value(text: training_period&.delivery_partner&.name)
     end
   end %>
   <hr class="govuk-section-break govuk-section-break--l" />
@@ -80,7 +86,13 @@
     end
     sl.with_row do |row|
       row.with_key(text: "Mentees")
-      row.with_value(text: school_period.mentees.join(", "))
+      row.with_value do
+        if school_period.mentees.any?
+          admin_teachers_list_links(school_period.mentees)
+        else
+          ""
+        end
+      end
     end
     sl.with_row do |row|
       row.with_key(text: "Lead provider")

--- a/app/views/migration/failures/index.html.erb
+++ b/app/views/migration/failures/index.html.erb
@@ -1,23 +1,33 @@
 <% page_data(title: "Migration failures for #{@model}", backlink_href: migration_migrations_path) %>
 
-<p class="govuk-body"><strong><%= @migration_failures.count %></strong> failed records</p>
+<p class="govuk-body"><strong><%= @pagy.count %></strong> failed records</p>
 
+<% if @model == "teacher" %>
 <%= govuk_table do |table|
   table.with_head do |head|
     head.with_row do |row|
-      row.with_cell(text: "No.")
-      row.with_cell(text: "Source record")
-      row.with_cell(text: "Validation failure")
+      row.with_cell(text: "Teacher")
+      row.with_cell(text: "Failure")
     end
   end
 
   table.with_body do |body|
     @migration_failures.each_with_index do |failure, index|
+      parent_link = govuk_link_to(Teachers::Name.new(failure.parent).full_name,
+                                  migration_teacher_details_path(failure.parent)) unless failure.parent.blank?
+
       body.with_row(html_attributes: { class: "govuk-!-font-size-16" }) do |row|
-        row.with_cell(text: index + 1)
-        row.with_cell(text: failure_item_json_code(failure.item))
-        row.with_cell(text: failure.failure_message)
+        if parent_link
+          row.with_cell { parent_link }
+          row.with_cell(text: failure.failure_type)
+        else
+          row.with_cell { govuk_tag(text: "Failed to create teacher", colour:  "red") }
+          row.with_cell(text: failure_item_json_code(failure.item))
+        end
       end
     end
   end
 end %>
+<% end %>
+<%= govuk_pagination pagy: @pagy %>
+

--- a/app/views/migration/teachers/_failures.html.erb
+++ b/app/views/migration/teachers/_failures.html.erb
@@ -1,0 +1,25 @@
+<% if failures.present? %>
+  <%= govuk_warning_text(text: "Some of this teacher's records could not be migrated") %>
+
+  <%= render Migration::MigrationFailureComponent.with_collection(failures) %>
+
+  <%#= govuk_table do |table|
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: "No.")
+        row.with_cell(text: "Source record")
+        row.with_cell(text: "Validation failure")
+      end
+    end
+
+    table.with_body do |body|
+      failures.each do |failure, index|
+        body.with_row(html_attributes: { class: "govuk-!-font-size-16" }) do |row|
+          row.with_cell(text: failure.failure_type)
+          row.with_cell(text: failure_item_json_code(failure.item))
+          row.with_cell(text: failure.failure_message)
+        end
+      end
+    end
+  end %>
+<% end %>

--- a/app/views/migration/teachers/_failures.html.erb
+++ b/app/views/migration/teachers/_failures.html.erb
@@ -2,24 +2,4 @@
   <%= govuk_warning_text(text: "Some of this teacher's records could not be migrated") %>
 
   <%= render Migration::MigrationFailureComponent.with_collection(failures) %>
-
-  <%#= govuk_table do |table|
-    table.with_head do |head|
-      head.with_row do |row|
-        row.with_cell(text: "No.")
-        row.with_cell(text: "Source record")
-        row.with_cell(text: "Validation failure")
-      end
-    end
-
-    table.with_body do |body|
-      failures.each do |failure, index|
-        body.with_row(html_attributes: { class: "govuk-!-font-size-16" }) do |row|
-          row.with_cell(text: failure.failure_type)
-          row.with_cell(text: failure_item_json_code(failure.item))
-          row.with_cell(text: failure.failure_message)
-        end
-      end
-    end
-  end %>
 <% end %>

--- a/app/views/migration/teachers/show.html.erb
+++ b/app/views/migration/teachers/show.html.erb
@@ -11,3 +11,4 @@
 
 <%= render partial: "ect_records", locals: { profile: @ect_profile } %>
 <%= render partial: "mentor_records", locals: { profile: @mentor_profile } %>
+<%= render partial: "failures", locals: { failures: @failures } %>


### PR DESCRIPTION
Adding more detail to teacher views
 - Error tag for teachers with migration errors in the main list view
 - Warning text to show that not all the teacher's records could be migrated in the teacher view
 - Summary of latest info in teacher view
 - Links to mentors/mentees and to School in teacher view
 - View of original `ParticipantProfile` and `InductionRecord`s for failures

Apologies for lack of screen shots but these would have prod data in and involve much redacting before showing here.
 