### PR TITLE
fix personas login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,8 +14,8 @@ class SessionsController < ApplicationController
       session_manager.begin_persona_session!(
         user_info.info.email,
         name: user_info.info.name,
-        appropriate_body_id: params["appropriate_body_id"]&.to_i,
-        school_urn: params["school_urn"]&.to_i
+        appropriate_body_id: params["appropriate_body_id"].presence,
+        school_urn: params["school_urn"].presence
       )
     when "dfe_sign_in"
       session_manager.begin_dfe_sign_in_session!(user_info)

--- a/app/services/sessions/session_user.rb
+++ b/app/services/sessions/session_user.rb
@@ -75,8 +75,8 @@ module Sessions
         "email" => email,
         "name" => name,
         "last_active_at" => last_active_at,
-        "appropriate_body_id" => appropriate_body_id&.to_i,
-        "school_urn" => school_urn&.to_i,
+        "appropriate_body_id" => appropriate_body_id.presence,
+        "school_urn" => school_urn.presence,
         "dfe" => dfe,
       }
     end


### PR DESCRIPTION
Currently when a school persona logs in, the service shows a page not found.
The reason is the way we store in the session the `school_urn` and `appropriate_body_id` of the persona.
Due to a bug it always logs as an appropriate body persona.

The problem is that `blank` values for `appropriate_body_id` and `school_urn` return zero when converted to integers (which is not a blank value). 

This PR stores them as nil (instead of 0) when they are blank, so the check for their presence will be accurate and the login code will detect the right type of persona.  