### PR TITLE
Playback ECT's corrected name on the ECT home page

### DIFF
--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -1,12 +1,13 @@
 module Schools
   class RegisterECT
-    attr_reader :first_name, :last_name, :school_urn, :started_on, :teacher, :trn
+    attr_reader :corrected_name, :first_name, :last_name, :school_urn, :started_on, :teacher, :trn
 
-    def initialize(first_name:, last_name:, trn:, school_urn:, started_on: Date.current)
+    def initialize(first_name:, last_name:, trn:, school_urn:, corrected_name:, started_on: Date.current)
       @first_name = first_name
       @last_name = last_name
       @school_urn = school_urn
       @started_on = started_on
+      @corrected_name = corrected_name
       @trn = trn
     end
 
@@ -20,7 +21,7 @@ module Schools
   private
 
     def create_teacher!
-      @teacher = ::Teacher.create!(first_name:, last_name:, trn:)
+      @teacher = ::Teacher.create!(first_name:, last_name:, trn:, corrected_name:)
     end
 
     def school

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -31,6 +31,7 @@ module Schools
       def register!
         Schools::RegisterECT.new(first_name: trs_first_name,
                                  last_name: trs_last_name,
+                                 corrected_name:,
                                  trn:,
                                  school_urn:)
                                .register_teacher!

--- a/spec/features/schools/register_an_ect/happy_path_spec.rb
+++ b/spec/features/schools/register_an_ect/happy_path_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def and_i_should_see_the_ect_i_registered
-    expect(page.get_by_role('link', name: 'Kirk Van Houten')).to be_visible
+    expect(page.get_by_role('link', name: 'Kirk Van Damme')).to be_visible
   end
 
   def then_i_should_be_taken_to_the_confirmation_page

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -1,6 +1,7 @@
 describe Schools::RegisterECT do
   let(:first_name) { "Dusty" }
   let(:last_name) { "Rhodes" }
+  let(:corrected_name) { "Randy Marsh" }
   let(:trn) { "3002586" }
   let(:school) { FactoryBot.create(:school) }
   let(:started_on) { Date.yesterday }
@@ -10,7 +11,8 @@ describe Schools::RegisterECT do
                         last_name:,
                         trn:,
                         school_urn: school.urn,
-                        started_on:)
+                        started_on:,
+                        corrected_name:)
   end
 
   describe '#register_teacher!' do
@@ -22,6 +24,7 @@ describe Schools::RegisterECT do
       expect(teacher.first_name).to eq(first_name)
       expect(teacher.last_name).to eq(last_name)
       expect(teacher.trn).to eq(trn)
+      expect(teacher.corrected_name).to eq(corrected_name)
     end
 
     it 'creates an associated ECTATSchoolPeriod record' do
@@ -35,7 +38,8 @@ describe Schools::RegisterECT do
         described_class.new(first_name:,
                             last_name:,
                             trn:,
-                            school_urn: school.urn)
+                            school_urn: school.urn,
+                            corrected_name:)
       end
 
       it "current date is assigned" do

--- a/spec/wizards/schools/register_ect/ect_spec.rb
+++ b/spec/wizards/schools/register_ect/ect_spec.rb
@@ -27,6 +27,16 @@ describe Schools::RegisterECTWizard::ECT do
     it 'returns the full name of the ECT' do
       expect(ect.full_name).to eq("Dusty Rhodes")
     end
+
+    context 'when corrected_name is set' do
+      before do
+        store.corrected_name = 'Randy Marsh'
+      end
+
+      it 'returns the corrected_name as the full name' do
+        expect(ect.full_name).to eq('Randy Marsh')
+      end
+    end
   end
 
   describe '#govuk_date_of_birth' do


### PR DESCRIPTION
### Ticket
#780 

### Changes
This is a follow up to this recent PR (https://github.com/DFE-Digital/register-early-career-teachers/pull/916)

- write the 'corrected' ECT name to the db
- playback the corrected name on the ECT home page

