### PR TITLE
Assign a mentor from the end of the ECT registration journey

### DIFF
--- a/app/views/schools/register_ect_wizard/confirmation.html.erb
+++ b/app/views/schools/register_ect_wizard/confirmation.html.erb
@@ -1,5 +1,13 @@
-<%= govuk_panel(title_text: "You have registered #{@ect.full_name} as an early career teacher") %>
+<% page_data(title: "You have saved #{@ect.full_name}'s details") %>
 
-<h2 class="govuk-heading-m">What happens next</h2>
-<p class="govuk-body">We’ll let this person know you’ve registered them for ECF-based training at your school. They do not need to provide us with any more information.</p>
-<%= govuk_link_to "Back to your ECTs", schools_ects_home_path %>
+<p class="govuk-body">We'll email them to let them know. They do not need to provide us with any more information.</p>
+
+<h2 class="govuk-heading-m">You still need to assign a mentor</h2>
+<p class="govuk-body">You can either assign a mentor now or return and do it later. You need to do this to complete
+  their registration.</p>
+
+<%= govuk_button_link_to("Assign a mentor", schools_register_mentor_wizard_start_path) %>
+
+<p class="govuk-body">
+  <%= govuk_link_to "Back to your ECTs", schools_ects_home_path %>
+</p>

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -3,7 +3,7 @@ module Schools
     class ECT < SimpleDelegator
       # This class is a decorator for the SessionRepository
       def full_name
-        corrected_name || [trs_first_name, trs_last_name].join(" ").strip
+        (corrected_name.presence || [trs_first_name, trs_last_name].join(" ").strip)
       end
 
       def govuk_date_of_birth

--- a/spec/views/schools/register_ect_wizard/confirmation.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/confirmation.html.erb_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "schools/register_ect_wizard/confirmation.html.erb" do
+  let(:ect) { double('ECT', full_name: 'John Doe') }
+  let(:title) { "You have saved #{ect.full_name}'s details" }
+  let(:ects_link) { schools_ects_home_path }
+  let(:assign_mentor_link) { schools_register_mentor_wizard_start_path }
+
+  before do
+    assign(:ect, ect)
+  end
+
+  it "sets the page title to 'You have saved John Doe's details" do
+    render
+
+    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  end
+
+  it "includes a link to view all ECTs" do
+    render
+
+    expect(rendered).to have_link('Back to your ECTs', href: ects_link)
+  end
+
+  it "includes a link to assign a mentor" do
+    render
+
+    expect(rendered).to have_link('Assign a mentor', href: assign_mentor_link)
+  end
+end


### PR DESCRIPTION
### Ticket
#834 

### Change 
- Update the confirmation step in the Register ECT wizard to allow users to assign a mentor

<img width="1157" alt="assign_a_mentor" src="https://github.com/user-attachments/assets/2d3be7f3-7df7-49b3-9096-15ebf221f645">